### PR TITLE
Apply the maven plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,9 @@ apply plugin: "org.sonarqube"
 apply plugin: 'net.researchgate.release'
 apply plugin: 'spring-boot'
 apply plugin: 'war'
-apply plugin: "org.sonarqube"
+apply plugin: 'org.sonarqube'
+// To embed into the release process. './gradlew' install will be called.
+apply plugin: 'maven'
 
 repositories {
 	mavenCentral()


### PR DESCRIPTION
Apply the maven plugin.

The maven plugin creates a gradle task called 'install'. That task is called during the release process.

This change enables to embed this project into the release process.