### PR TITLE
prefer Optional over null objects & script execution fix

### DIFF
--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/CloudManager.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/CloudManager.java
@@ -68,7 +68,7 @@ public class CloudManager {
         return cloudProviderPerType.get(infrastructure.getType()).getAllInfrastructureInstances(infrastructure);
     }
 
-    public ScriptResult executeScriptOnInstanceId(Infrastructure infrastructure, String instanceId,
+    public List<ScriptResult> executeScriptOnInstanceId(Infrastructure infrastructure, String instanceId,
             InstanceScript instanceScript) {
         return cloudProviderPerType.get(infrastructure.getType()).executeScriptOnInstanceId(infrastructure,
                                                                                             instanceId,

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/CloudProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/CloudProvider.java
@@ -45,7 +45,7 @@ public interface CloudProvider {
 
     public Set<Instance> getAllInfrastructureInstances(Infrastructure infrastructure);
 
-    public ScriptResult executeScriptOnInstanceId(Infrastructure infrastructure, String instanceId,
+    public List<ScriptResult> executeScriptOnInstanceId(Infrastructure infrastructure, String instanceId,
             InstanceScript instanceScript);
 
     public List<ScriptResult> executeScriptOnInstanceTag(Infrastructure infrastructure, String instanceTag,

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsProvider.java
@@ -81,7 +81,7 @@ public abstract class JCloudsProvider implements CloudProvider {
     }
 
     @Override
-    public ScriptResult executeScriptOnInstanceId(Infrastructure infrastructure, String instanceId,
+    public List<ScriptResult> executeScriptOnInstanceId(Infrastructure infrastructure, String instanceId,
             InstanceScript instanceScript) {
         ExecResponse execResponse;
 
@@ -93,7 +93,7 @@ public abstract class JCloudsProvider implements CloudProvider {
             throw new RuntimeException(e);
         }
 
-        return new ScriptResult(instanceId, execResponse.getOutput(), execResponse.getError());
+        return Lists.newArrayList(new ScriptResult(instanceId, execResponse.getOutput(), execResponse.getError()));
     }
 
     @Override

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/vmware/VMWareProviderVirtualMachineUtil.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/vmware/VMWareProviderVirtualMachineUtil.java
@@ -75,7 +75,7 @@ public class VMWareProviderVirtualMachineUtil {
 
     public Optional<VirtualMachine> searchVirtualMachineByUUID(String uuid, Folder rootFolder) {
         try {
-            return Lists.newArrayList(new InventoryNavigator(rootFolder).searchManagedEntities("VirtualMachine"))
+            return Lists.newArrayList(new InventoryNavigator(rootFolder).searchManagedEntities(EntityType.VM.getValue()))
                         .stream()
                         .map(virtualMachine -> (VirtualMachine) virtualMachine)
                         .filter(virtualMachine -> virtualMachine.getConfig() != null)

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/vmware/VMWareProviderVirtualMachineUtil.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/vmware/VMWareProviderVirtualMachineUtil.java
@@ -29,6 +29,7 @@ import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -38,6 +39,7 @@ import org.ow2.proactive.connector.iaas.model.Infrastructure;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Lists;
+import com.vmware.vim25.VirtualMachineRelocateSpec;
 import com.vmware.vim25.mo.Datastore;
 import com.vmware.vim25.mo.Folder;
 import com.vmware.vim25.mo.HostSystem;
@@ -64,23 +66,30 @@ public class VMWareProviderVirtualMachineUtil {
         private final String value;
     }
 
-    public VirtualMachine searchVirtualMachineByName(String name, Folder rootFolder) throws RemoteException {
-        return (VirtualMachine) new InventoryNavigator(rootFolder).searchManagedEntity(EntityType.VM.getValue(), name);
-    }
-
-    public VirtualMachine searchVirtualMachineByUUID(String uuid, Folder rootFolder) throws RemoteException {
-        return Lists.newArrayList(new InventoryNavigator(rootFolder).searchManagedEntities("VirtualMachine"))
-                    .stream()
-                    .map(virtualMachine -> (VirtualMachine) virtualMachine)
-                    .filter(virtualMachine -> virtualMachine.getConfig() != null)
-                    .filter(virtualMachine -> virtualMachine.getConfig().getUuid().equals(uuid))
-                    .findFirst()
-                    .orElse(null);
-    }
-
-    public Set<VirtualMachine> getAllVirtualMachinesByInfrastructure(Folder rootFolder, Infrastructure infrastructure) {
+    public Optional<VirtualMachine> searchVirtualMachineByName(String name, Folder rootFolder) {
         try {
+            return Optional.ofNullable((VirtualMachine) new InventoryNavigator(rootFolder).searchManagedEntity(EntityType.VM.getValue(),
+                                                                                                               name));
+        } catch (RemoteException e) {
+            throw new RuntimeException("ERROR when retrieving VMWare virtual machine with name: " + name, e);
+        }
+    }
 
+    public Optional<VirtualMachine> searchVirtualMachineByUUID(String uuid, Folder rootFolder) {
+        try {
+            return Lists.newArrayList(new InventoryNavigator(rootFolder).searchManagedEntities("VirtualMachine"))
+                        .stream()
+                        .map(virtualMachine -> (VirtualMachine) virtualMachine)
+                        .filter(virtualMachine -> virtualMachine.getConfig() != null)
+                        .filter(virtualMachine -> virtualMachine.getConfig().getUuid().equals(uuid))
+                        .findFirst();
+        } catch (RemoteException e) {
+            throw new RuntimeException("ERROR when retrieving VMWare virtual machines" + uuid, e);
+        }
+    }
+
+    public Set<VirtualMachine> getAllVirtualMachines(Folder rootFolder) {
+        try {
             ManagedEntity[] managedEntities = new InventoryNavigator(rootFolder).searchManagedEntities(EntityType.VM.getValue());
 
             return IntStream.range(0, managedEntities.length)
@@ -88,67 +97,97 @@ public class VMWareProviderVirtualMachineUtil {
                             .collect(Collectors.toSet());
 
         } catch (RemoteException e) {
-            throw new RuntimeException("ERROR when retrieving VMWare instances for infrastructure : " + infrastructure,
-                                       e);
+            throw new RuntimeException("ERROR when retrieving VMWare virtual machines", e);
         }
     }
 
-    public Folder searchFolderByName(String name, Folder rootFolder) throws RemoteException {
-        return (Folder) new InventoryNavigator(rootFolder).searchManagedEntity(EntityType.FOLDER.getValue(), name);
-    }
-
-    public HostSystem searchHostByName(String name, Folder rootFolder) throws RemoteException {
-        return (HostSystem) new InventoryNavigator(rootFolder).searchManagedEntity(EntityType.HOST.getValue(), name);
-    }
-
-    public Folder searchVMFolderFromVMName(String name, Folder rootFolder) throws RemoteException {
-        ManagedEntity current = searchVirtualMachineByName(name, rootFolder).getParent();
-        while (!(current instanceof Folder)) {
-            current = current.getParent();
+    public Optional<HostSystem> searchHostByName(String name, Folder rootFolder) {
+        try {
+            return Optional.ofNullable((HostSystem) new InventoryNavigator(rootFolder).searchManagedEntity(EntityType.HOST.getValue(),
+                                                                                                           name));
+        } catch (RemoteException e) {
+            throw new RuntimeException("ERROR when retrieving VMWare host with name: " + name, e);
         }
-        return (Folder) current;
     }
 
-    public Folder searchVMFolderByHostname(String name, Folder rootFolder) throws RemoteException {
-        return Lists.newArrayList(new InventoryNavigator(rootFolder).searchManagedEntities(EntityType.FOLDER.getValue()))
-                    .stream()
-                    .map(folder -> (Folder) folder)
-                    .filter(folder -> folder.getName().toLowerCase().contains("vm") &&
-                                      folder.getName().toLowerCase().contains(name.toLowerCase()))
-                    .findAny()
-                    .orElse(null);
+    public Optional<Folder> searchFolderByName(String name, Folder rootFolder) {
+        try {
+            return Optional.ofNullable((Folder) new InventoryNavigator(rootFolder).searchManagedEntity("Folder", name));
+        } catch (RemoteException e) {
+            throw new RuntimeException("ERROR when retrieving VMWare folder with name: " + name, e);
+        }
     }
 
-    public ResourcePool searchResourcePoolByHostname(String hostname, Folder rootFolder) throws RemoteException {
-        return Lists.newArrayList(new InventoryNavigator(rootFolder).searchManagedEntities(EntityType.POOL.getValue()))
-                    .stream()
-                    .map(resourcePool -> (ResourcePool) resourcePool)
-                    .filter(resourcePool -> resourcePool.getParent().getName().equals(hostname))
-                    .findAny()
-                    .orElse(null);
+    public Optional<Folder> searchVMFolderFromVMName(String name, Folder rootFolder) {
+        final ManagedEntity[] vmFolder = new Folder[1];
+        searchVirtualMachineByName(name, rootFolder).ifPresent(vm -> {
+            ManagedEntity current = vm.getParent();
+            while (current != null && !(current instanceof Folder)) {
+                current = current.getParent();
+            }
+            vmFolder[0] = current;
+        });
+        return Optional.ofNullable((Folder) vmFolder[0]);
     }
 
-    public Datastore getDatastoreWithMostSpaceFromHost(HostSystem host) throws RemoteException {
-        return Lists.newArrayList(host.getDatastores())
-                    .stream()
-                    .filter(datastore -> datastore.getSummary().isAccessible())
-                    .max(Comparator.comparing(datastore -> (int) datastore.getSummary().getFreeSpace()))
-                    .orElseGet(null);
+    public Optional<Folder> searchVMFolderByHostname(String hostname, Folder rootFolder) {
+        try {
+            return Lists.newArrayList(new InventoryNavigator(rootFolder).searchManagedEntities(EntityType.FOLDER.getValue()))
+                        .stream()
+                        .map(folder -> (Folder) folder)
+                        .filter(folder -> folder.getName().toLowerCase().contains("vm") &&
+                                          folder.getName().toLowerCase().contains(hostname.toLowerCase()))
+                        .findAny();
+        } catch (RemoteException e) {
+            throw new RuntimeException("ERROR when retrieving VMWare folders", e);
+        }
     }
 
-    public Datastore getDatastoreWithMostSpaceFromPool(ResourcePool resourcePool) throws RemoteException {
-        return Lists.newArrayList(resourcePool.getOwner().getDatastores())
-                    .stream()
-                    .filter(datastore -> datastore.getSummary().isAccessible())
-                    .max(Comparator.comparing(datastore -> (int) datastore.getSummary().getFreeSpace()))
-                    .orElseGet(null);
+    public Optional<ResourcePool> searchResourcePoolByHostname(String hostname, Folder rootFolder) {
+        try {
+            return Lists.newArrayList(new InventoryNavigator(rootFolder).searchManagedEntities(EntityType.POOL.getValue()))
+                        .stream()
+                        .map(resourcePool -> (ResourcePool) resourcePool)
+                        .filter(resourcePool -> resourcePool.getParent().getName().equals(hostname))
+                        .findAny();
+        } catch (RemoteException e) {
+            throw new RuntimeException("ERROR when retrieving VMWare resource pools", e);
+        }
     }
 
-    public ResourcePool getRandomResourcePool(Folder rootFolder) throws RemoteException {
-        List<ResourcePool> resourcePools = Lists.newArrayList(new InventoryNavigator(rootFolder).searchManagedEntities(EntityType.POOL.getValue()))
-                                                .stream()
-                                                .map(resourcePool -> (ResourcePool) resourcePool)
-                                                .collect(Collectors.toCollection(ArrayList::new));
-        return resourcePools.isEmpty() ? null : resourcePools.get(new Random().nextInt(resourcePools.size()));
+    public Optional<Datastore> getDatastoreWithMostSpaceFromHost(HostSystem host) {
+        try {
+            return Lists.newArrayList(host.getDatastores())
+                        .stream()
+                        .filter(datastore -> datastore.getSummary().isAccessible())
+                        .max(Comparator.comparing(datastore -> (int) datastore.getSummary().getFreeSpace()));
+        } catch (RemoteException e) {
+            throw new RuntimeException("ERROR when retrieving VMWare datastores from host: " + host.getName(), e);
+        }
+    }
+
+    public Optional<Datastore> getDatastoreWithMostSpaceFromPool(ResourcePool resourcePool) {
+        try {
+            return Lists.newArrayList(resourcePool.getOwner().getDatastores())
+                        .stream()
+                        .filter(datastore -> datastore.getSummary().isAccessible())
+                        .max(Comparator.comparing(datastore -> (int) datastore.getSummary().getFreeSpace()));
+        } catch (RemoteException e) {
+            throw new RuntimeException("ERROR when retrieving VMWare resource pool's owner from: " +
+                                       resourcePool.getName(), e);
+        }
+    }
+
+    public Optional<ResourcePool> getRandomResourcePool(Folder rootFolder) {
+        List<ResourcePool> resourcePools = null;
+        try {
+            resourcePools = Lists.newArrayList(new InventoryNavigator(rootFolder).searchManagedEntities(EntityType.POOL.getValue()))
+                                 .stream()
+                                 .map(resourcePool -> (ResourcePool) resourcePool)
+                                 .collect(Collectors.toCollection(ArrayList::new));
+        } catch (RemoteException e) {
+            throw new RuntimeException("ERROR when retrieving VMWare resource pool", e);
+        }
+        return Optional.ofNullable(resourcePools.get(new Random().nextInt(resourcePools.size())));
     }
 }

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/vmware/VMWareProviderVirtualMachineUtil.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/vmware/VMWareProviderVirtualMachineUtil.java
@@ -112,7 +112,7 @@ public class VMWareProviderVirtualMachineUtil {
 
     public Optional<Folder> searchFolderByName(String name, Folder rootFolder) {
         try {
-            return Optional.ofNullable((Folder) new InventoryNavigator(rootFolder).searchManagedEntity("Folder", name));
+            return Optional.ofNullable((Folder) new InventoryNavigator(rootFolder).searchManagedEntity(EntityType.FOLDER.getValue(), name));
         } catch (RemoteException e) {
             throw new RuntimeException("ERROR when retrieving VMWare folder with name: " + name, e);
         }

--- a/src/main/java/org/ow2/proactive/connector/iaas/service/InstanceScriptService.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/service/InstanceScriptService.java
@@ -46,7 +46,7 @@ public class InstanceScriptService {
     @Autowired
     private CloudManager cloudManager;
 
-    public ScriptResult executeScriptOnInstance(String infrastructureId, String instanceId,
+    public List<ScriptResult> executeScriptOnInstance(String infrastructureId, String instanceId,
             InstanceScript instanceScript) {
 
         return Optional.ofNullable(infrastructureService.getInfrastructure(infrastructureId))

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.is;
 import static org.jclouds.compute.predicates.NodePredicates.runningInGroup;
 import static org.jclouds.scriptbuilder.domain.Statements.exec;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -587,13 +588,14 @@ public class AWSEC2JCloudsProviderTest {
                                             Mockito.anyString(),
                                             Mockito.any(RunScriptOptions.class))).thenReturn(execResponse);
 
-        ScriptResult scriptResult = jcloudsProvider.executeScriptOnInstanceId(infrastructure,
-                                                                              "instanceId",
-                                                                              InstanceScriptFixture.simpleInstanceScriptNoscripts());
+        List<ScriptResult> scriptResults = jcloudsProvider.executeScriptOnInstanceId(infrastructure,
+                                                                                     "instanceId",
+                                                                                     InstanceScriptFixture.simpleInstanceScriptNoscripts());
 
-        assertThat(scriptResult.getInstanceId(), is("instanceId"));
-        assertThat(scriptResult.getOutput(), is("output"));
-        assertThat(scriptResult.getError(), is("error"));
+        assertTrue(scriptResults.size() == 1);
+        assertThat(scriptResults.get(0).getInstanceId(), is("instanceId"));
+        assertThat(scriptResults.get(0).getOutput(), is("output"));
+        assertThat(scriptResults.get(0).getError(), is("error"));
 
     }
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.is;
 import static org.jclouds.compute.predicates.NodePredicates.runningInGroup;
 import static org.jclouds.scriptbuilder.domain.Statements.exec;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -373,13 +374,14 @@ public class OpenstackJCloudsProviderTest {
                                             Mockito.anyString(),
                                             Mockito.any(RunScriptOptions.class))).thenReturn(execResponse);
 
-        ScriptResult scriptResult = jcloudsProvider.executeScriptOnInstanceId(infrastructure,
-                                                                              "instanceId",
-                                                                              InstanceScriptFixture.simpleInstanceScriptNoscripts());
+        List<ScriptResult> scriptResults = jcloudsProvider.executeScriptOnInstanceId(infrastructure,
+                                                                                     "instanceId",
+                                                                                     InstanceScriptFixture.simpleInstanceScriptNoscripts());
 
-        assertThat(scriptResult.getInstanceId(), is("instanceId"));
-        assertThat(scriptResult.getOutput(), is("output"));
-        assertThat(scriptResult.getError(), is("error"));
+        assertTrue(scriptResults.size() == 1);
+        assertThat(scriptResults.get(0).getInstanceId(), is("instanceId"));
+        assertThat(scriptResults.get(0).getOutput(), is("output"));
+        assertThat(scriptResults.get(0).getError(), is("error"));
 
     }
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/rest/InstanceScriptRestTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/rest/InstanceScriptRestTest.java
@@ -65,7 +65,7 @@ public class InstanceScriptRestTest {
 
         when(instanceScriptService.executeScriptOnInstance(Mockito.anyString(),
                                                            Mockito.anyString(),
-                                                           Mockito.any(InstanceScript.class))).thenReturn(scriptResult);
+                                                           Mockito.any(InstanceScript.class))).thenReturn(Lists.newArrayList(scriptResult));
 
         assertThat(instanceScriptRest.executeScript("infrastructureId",
                                                     "instanceId",

--- a/src/test/java/org/ow2/proactive/connector/iaas/service/InstanceScriptServiceTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/service/InstanceScriptServiceTest.java
@@ -27,6 +27,7 @@ package org.ow2.proactive.connector.iaas.service;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -77,16 +78,17 @@ public class InstanceScriptServiceTest {
 
         when(cloudManager.executeScriptOnInstanceId(infrastructure,
                                                     "instanceId",
-                                                    instanceScript)).thenReturn(new ScriptResult("instanceId",
-                                                                                                 "output",
-                                                                                                 "error"));
+                                                    instanceScript)).thenReturn(Lists.newArrayList(new ScriptResult("instanceId",
+                                                                                                                    "output",
+                                                                                                                    "error")));
 
-        ScriptResult scriptResult = instanceScriptService.executeScriptOnInstance(infrastructure.getId(),
-                                                                                  "instanceId",
-                                                                                  instanceScript);
+        List<ScriptResult> scriptResults = instanceScriptService.executeScriptOnInstance(infrastructure.getId(),
+                                                                                         "instanceId",
+                                                                                         instanceScript);
 
-        assertThat(scriptResult.getOutput(), is(scriptResult.getOutput()));
-        assertThat(scriptResult.getError(), is(scriptResult.getError()));
+        assertTrue(scriptResults.size() == 1);
+        assertThat(scriptResults.get(0).getOutput(), is("output"));
+        assertThat(scriptResults.get(0).getError(), is("error"));
 
         verify(cloudManager, times(1)).executeScriptOnInstanceId(infrastructure, "instanceId", instanceScript);
 


### PR DESCRIPTION
Changes list:
- return Optional instead of potentially null objects from vmWareProviderVirtualMachineUtil
- manage remote API errors inside vmWareProviderVirtualMachineUtil class by throwing RuntimeException
- use String's equals method for task results comparison
- consistently retrieve a List of ScriptResult in both executeScriptOnInstanceId and executeScriptOnInstanceTag
- test updated & some code cleaning/improvement

TODO:
- update nodesource-addons for resource-manager compatibility