### PR TITLE
New MAAS (Metal as a Service) infrastructure.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ install {
 }
 
 repositories {
+    maven {
+        url "http://repository.activeeon.com/content/groups/proactive/"
+    }
     // Needed by Microsoft Azure Java SDK
     maven {
         url "http://repository.springsource.com/maven/bundles/release"
@@ -103,6 +106,8 @@ compileJava {
 }
 
 dependencies {
+    compile 'org.ow2.proactive:maas-rest-client:1.0-SNAPSHOT'
+
     // Lombok plugin to remove boilerplate code from project
     compile 'org.projectlombok:lombok:1.16.6'
     // Guava allows immutable classes/objects

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jul 18 12:01:20 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
@@ -1,0 +1,158 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.connector.iaas.cloud.provider.maas;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.ws.rs.NotSupportedException;
+
+import org.apache.log4j.Logger;
+import org.ow2.proactive.connector.iaas.cloud.provider.CloudProvider;
+import org.ow2.proactive.connector.iaas.model.Hardware;
+import org.ow2.proactive.connector.iaas.model.Image;
+import org.ow2.proactive.connector.iaas.model.Infrastructure;
+import org.ow2.proactive.connector.iaas.model.Instance;
+import org.ow2.proactive.connector.iaas.model.InstanceScript;
+import org.ow2.proactive.connector.iaas.model.Network;
+import org.ow2.proactive.connector.iaas.model.ScriptResult;
+import org.ow2.proactive.connector.maas.data.CommissioningScript;
+import org.ow2.proactive.connector.maas.data.Machine;
+import org.ow2.proactive.connector.maas.data.powertype.IpmiPowerType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.google.common.collect.Sets;
+
+import lombok.Getter;
+
+/**
+ * @author Vicent Kherbache
+ * @since 09/01/17
+ */
+@Component
+public class MaasProvider implements CloudProvider {
+
+    private final Logger logger = Logger.getLogger(MaasProvider.class);
+
+    @Getter
+    private final String type = "maas";
+
+    @Autowired
+    private MaasProviderClientCache maasProviderClientCache;
+
+    @Override
+    public Set<Instance> createInstance(Infrastructure infrastructure, Instance instance) {
+
+        // TODO: need to be adjusted to match exact parameters from nodesource-addons
+        Set<Instance> instances = IntStream.rangeClosed(1, Integer.valueOf(instance.getNumber()))
+                .mapToObj(instanceIndexStartAt1 -> maasProviderClientCache.getMaasClient(infrastructure)
+                        .createMachine(new Machine.Builder()
+                                .hostName(createUniqInstanceTag(instance.getTag(),instanceIndexStartAt1))
+                                .architecture(instance.getHardware().getType())
+                                .powerType(new IpmiPowerType.Builder()
+                                        .powerAddress(instance.getOptions().getSubnetId())
+                                        .macAddress(instance.getOptions().getMacAddresses().get(0)).build())
+                                .macAddress(instance.getOptions().getMacAddresses().get(0))))
+                .map(machine -> getInstanceFromMachine(infrastructure, machine))
+                .collect(Collectors.toSet());
+        // Add instances to the list
+        infrastructure.getInstances().addAll(instances);
+        return instances;
+    }
+
+    @Override
+    public void deleteInstance(Infrastructure infrastructure, String instanceId) {
+
+        if (!maasProviderClientCache.getMaasClient(infrastructure).deleteMachine(instanceId)) {
+            throw new RuntimeException("ERROR when deleting MAAS instance : " + instanceId);
+        }
+    }
+
+    private Instance getInstanceFromMachine(Infrastructure infrastructure, Machine machine) {
+
+        return Instance.builder().id(machine.getSystemId()).tag(machine.getHostname())
+                .number("1").hardware(Hardware.builder().minCores(machine.getCpuCount().toString())
+                                .minRam(machine.getMemory().toString()).type(machine.getNodeTypeName()).build())
+                .network(Network.builder().publicAddresses(Sets.newHashSet(machine.getIpAddresses())).build())
+                .status(machine.getStatusMessage()).build();
+    }
+
+    @Override
+    public ScriptResult executeScriptOnInstanceId(Infrastructure infrastructure, String instanceId, InstanceScript instanceScript) {
+
+        ScriptResult scriptResult = new ScriptResult(instanceId, "", "");
+
+        StringBuilder script = new StringBuilder();
+        script.append("#!/bin/bash\n");
+        for (int i = 0; i < instanceScript.getScripts().length; i++) {
+            script.append("\n");
+            script.append(instanceScript.getScripts()[i]);
+        }
+
+        CommissioningScript maasScript = maasProviderClientCache.getMaasClient(infrastructure)
+                .postCommissioningScript(script.toString().getBytes(), instanceScript.getName());
+
+        if (maasScript == null) {
+            return scriptResult.withError("Unable to upload script " +  instanceScript.getName());
+        }
+        return scriptResult.withOutput(maasScript.getResourceUri());
+    }
+
+    @Override
+    public List<ScriptResult> executeScriptOnInstanceTag(Infrastructure infrastructure, String instanceTag, InstanceScript instanceScript) {
+
+        return maasProviderClientCache.getMaasClient(infrastructure).getMachines().stream()
+                .filter(machine -> machine.getHostname().equals(instanceTag))
+                .map(machine -> executeScriptOnInstanceId(infrastructure, machine.getSystemId(), instanceScript))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Set<Image> getAllImages(Infrastructure infrastructure) {
+        throw new NotSupportedException("Operation not supported for MAAS");
+    }
+
+    @Override
+    public void deleteInfrastructure(Infrastructure infrastructure) {
+        // Remove only DESIRED instances
+        infrastructure.getInstances().stream()
+                .map(Instance::getId).forEach(id -> deleteInstance(infrastructure, id));
+        maasProviderClientCache.removeMaasClient(infrastructure);
+    }
+
+    @Override
+    public String addToInstancePublicIp(Infrastructure infrastructure, String instanceId) {
+        throw new NotSupportedException("Operation not supported for MAAS");
+    }
+
+    @Override
+    public void removeInstancePublicIp(Infrastructure infrastructure, String instanceId) {
+        throw new NotSupportedException("Operation not supported for MAAS");
+    }
+}

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
@@ -193,4 +193,21 @@ public class MaasProvider implements CloudProvider {
     public void removeInstancePublicIp(Infrastructure infrastructure, String instanceId, String desiredIp) {
         throw new NotSupportedException("Operation not supported for MAAS");
     }
+
+    private Instance getInstanceFromMachine(Machine machine) {
+
+        return Instance.builder().id(machine.getSystemId()).tag(machine.getHostname())
+                .number("1").hardware(Hardware.builder().minCores(machine.getCpuCount().toString())
+                        .minRam(machine.getMemory().toString()).type(machine.getNodeTypeName()).build())
+                .network(Network.builder().publicAddresses(Lists.newArrayList(machine.getIpAddresses())).build())
+                .status(machine.getStatusMessage()).build();
+    }
+
+    private List<org.ow2.proactive.connector.maas.data.Tag> convertIaasTagsToMaasTags(List<Tag> iaasTags){
+        return iaasTags.stream().map(this::convertIaasTagToMaasTag).collect(Collectors.toList());
+    }
+
+    private org.ow2.proactive.connector.maas.data.Tag convertIaasTagToMaasTag(Tag iaasTag){
+        return new org.ow2.proactive.connector.maas.data.Tag(null, null, iaasTag.getKey(), iaasTag.getValue(), null);
+    }
 }

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
@@ -102,7 +102,8 @@ public class MaasProvider implements CloudProvider {
                                                                                                                                   .getMinCores()),
                                                                                                           Integer.valueOf(instance.getHardware()
                                                                                                                                   .getMinRam()),
-                                                                                                          "",
+                                                                                                          instance.getInitScript()
+                                                                                                                  .getScripts()[0],
                                                                                                           tags))
                                       .collect(Collectors.toList());
         }

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
@@ -185,12 +185,12 @@ public class MaasProvider implements CloudProvider {
     }
 
     @Override
-    public String addToInstancePublicIp(Infrastructure infrastructure, String instanceId) {
+    public String addToInstancePublicIp(Infrastructure infrastructure, String instanceId, String desiredIp) {
         throw new NotSupportedException("Operation not supported for MAAS");
     }
 
     @Override
-    public void removeInstancePublicIp(Infrastructure infrastructure, String instanceId) {
+    public void removeInstancePublicIp(Infrastructure infrastructure, String instanceId, String desiredIp) {
         throw new NotSupportedException("Operation not supported for MAAS");
     }
 }

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
@@ -181,9 +181,6 @@ public class MaasProvider implements CloudProvider {
 
     @Override
     public void deleteInfrastructure(Infrastructure infrastructure) {
-        // Remove only DESIRED instances
-        infrastructure.getInstances().stream()
-                .map(Instance::getId).forEach(id -> deleteInstance(infrastructure, id));
         maasProviderClientCache.removeMaasClient(infrastructure);
     }
 

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProvider.java
@@ -118,8 +118,7 @@ public class MaasProvider implements CloudProvider {
 
     @Override
     public void deleteInstance(Infrastructure infrastructure, String instanceId) {
-
-        if (!maasProviderClientCache.getMaasClient(infrastructure).deleteMachine(instanceId)) {
+        if (!maasProviderClientCache.getMaasClient(infrastructure).releaseMachineById(instanceId)) {
             throw new RuntimeException("ERROR when deleting MAAS instance : " + instanceId);
         }
     }

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientBuilder.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientBuilder.java
@@ -1,0 +1,50 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.connector.iaas.cloud.provider.maas;
+
+import org.ow2.proactive.connector.iaas.model.Infrastructure;
+import org.ow2.proactive.connector.maas.MaasClient;
+import org.springframework.remoting.RemoteConnectFailureException;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author ActiveEon Team
+ * @since 12/01/17
+ */
+@Component
+public class MaasProviderClientBuilder {
+
+    public MaasClient buildMaasClientFromInfrastructure(Infrastructure infrastructure) {
+
+        // TODO: add ignoreCert boolean !!
+        try {
+            return new MaasClient(infrastructure.getEndpoint(), infrastructure.getCredentials().getPassword());
+        } catch(RemoteConnectFailureException e) {
+            throw new RuntimeException(
+                    "ERROR trying to create MaasClient with infrastructure : " + infrastructure, e);
+        }
+    }
+}

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientBuilder.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientBuilder.java
@@ -39,9 +39,8 @@ public class MaasProviderClientBuilder {
 
     public MaasClient buildMaasClientFromInfrastructure(Infrastructure infrastructure) {
 
-        // TODO: add ignoreCert boolean !!
         try {
-            return new MaasClient(infrastructure.getEndpoint(), infrastructure.getCredentials().getPassword());
+            return new MaasClient(infrastructure.getEndpoint(), infrastructure.getCredentials().getPassword(), infrastructure.getCredentials().isAllowSelfSignedSSLCertificate());
         } catch(RemoteConnectFailureException e) {
             throw new RuntimeException(
                     "ERROR trying to create MaasClient with infrastructure : " + infrastructure, e);

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientBuilder.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientBuilder.java
@@ -43,7 +43,7 @@ public class MaasProviderClientBuilder {
         try {
             return new MaasClient(infrastructure.getEndpoint(),
                                   infrastructure.getCredentials().getPassword(),
-                                  infrastructure.getCredentials().isAllowSelfSignedSSLCertificate());
+                                  infrastructure.isAllowSelfSignedSSLCertificate());
         } catch (RemoteConnectFailureException e) {
             throw new RuntimeException("ERROR trying to create MaasClient with infrastructure : " + infrastructure, e);
         }

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientBuilder.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientBuilder.java
@@ -30,6 +30,7 @@ import org.ow2.proactive.connector.maas.MaasClient;
 import org.springframework.remoting.RemoteConnectFailureException;
 import org.springframework.stereotype.Component;
 
+
 /**
  * @author ActiveEon Team
  * @since 12/01/17
@@ -40,10 +41,11 @@ public class MaasProviderClientBuilder {
     public MaasClient buildMaasClientFromInfrastructure(Infrastructure infrastructure) {
 
         try {
-            return new MaasClient(infrastructure.getEndpoint(), infrastructure.getCredentials().getPassword(), infrastructure.getCredentials().isAllowSelfSignedSSLCertificate());
-        } catch(RemoteConnectFailureException e) {
-            throw new RuntimeException(
-                    "ERROR trying to create MaasClient with infrastructure : " + infrastructure, e);
+            return new MaasClient(infrastructure.getEndpoint(),
+                                  infrastructure.getCredentials().getPassword(),
+                                  infrastructure.getCredentials().isAllowSelfSignedSSLCertificate());
+        } catch (RemoteConnectFailureException e) {
+            throw new RuntimeException("ERROR trying to create MaasClient with infrastructure : " + infrastructure, e);
         }
     }
 }

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientCache.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientCache.java
@@ -1,0 +1,67 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.connector.iaas.cloud.provider.maas;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import org.ow2.proactive.connector.iaas.model.Infrastructure;
+import org.ow2.proactive.connector.maas.MaasClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author ActiveEon Team
+ * @since 12/01/17
+ */
+@Component
+public class MaasProviderClientCache {
+
+    @Autowired
+    private MaasProviderClientBuilder maasClientBuilder;
+
+    private Map<Infrastructure, MaasClient> maasClientCache;
+
+    public MaasProviderClientCache() {
+        maasClientCache = new ConcurrentHashMap<Infrastructure, MaasClient>();
+    }
+
+    public MaasClient getMaasClient(Infrastructure infrastructure) {
+        return buildMaasClient.apply(infrastructure);
+    }
+
+    public void removeMaasClient(Infrastructure infrastructure) {
+        maasClientCache.remove(infrastructure);
+    }
+
+    private Function<Infrastructure, MaasClient> buildMaasClient = memorise(
+            maasClientBuilder::buildMaasClientFromInfrastructure);
+
+    private Function<Infrastructure, MaasClient> memorise(Function<Infrastructure, MaasClient> fn) {
+        return (a) -> maasClientCache.computeIfAbsent(a, fn);
+    }
+}

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientCache.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientCache.java
@@ -58,10 +58,10 @@ public class MaasProviderClientCache {
         maasClientCache.remove(infrastructure);
     }
 
-    private Function<Infrastructure, MaasClient> buildMaasClient = memorise(
-            maasClientBuilder::buildMaasClientFromInfrastructure);
+    private Function<Infrastructure, MaasClient> buildMaasClient = memoise(infrastructure ->
+            maasClientBuilder.buildMaasClientFromInfrastructure(infrastructure));
 
-    private Function<Infrastructure, MaasClient> memorise(Function<Infrastructure, MaasClient> fn) {
+    private Function<Infrastructure, MaasClient> memoise(Function<Infrastructure, MaasClient> fn) {
         return (a) -> maasClientCache.computeIfAbsent(a, fn);
     }
 }

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientCache.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientCache.java
@@ -34,6 +34,7 @@ import org.ow2.proactive.connector.maas.MaasClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+
 /**
  * @author ActiveEon Team
  * @since 12/01/17
@@ -58,8 +59,7 @@ public class MaasProviderClientCache {
         maasClientCache.remove(infrastructure);
     }
 
-    private Function<Infrastructure, MaasClient> buildMaasClient = memoise(infrastructure ->
-            maasClientBuilder.buildMaasClientFromInfrastructure(infrastructure));
+    private Function<Infrastructure, MaasClient> buildMaasClient = memoise(infrastructure -> maasClientBuilder.buildMaasClientFromInfrastructure(infrastructure));
 
     private Function<Infrastructure, MaasClient> memoise(Function<Infrastructure, MaasClient> fn) {
         return (a) -> maasClientCache.computeIfAbsent(a, fn);

--- a/src/main/java/org/ow2/proactive/connector/iaas/model/Infrastructure.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/model/Infrastructure.java
@@ -33,7 +33,8 @@ import lombok.ToString;
 
 
 @EqualsAndHashCode(exclude = { "type", "endpoint", "credentials", "authenticationEndpoint", "managementEndpoint",
-                               "resourceManagerEndpoint", "graphEndpoint", "toBeRemovedOnShutdown" })
+                               "resourceManagerEndpoint", "graphEndpoint", "toBeRemovedOnShutdown",
+                               "allowSelfSignedSSLCertificate" })
 @Getter
 @AllArgsConstructor
 @ToString
@@ -55,6 +56,8 @@ public class Infrastructure {
     private String resourceManagerEndpoint;
 
     private String graphEndpoint;
+
+    private boolean allowSelfSignedSSLCertificate;
 
     private boolean toBeRemovedOnShutdown;
 }

--- a/src/main/java/org/ow2/proactive/connector/iaas/model/InfrastructureCredentials.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/model/InfrastructureCredentials.java
@@ -46,6 +46,4 @@ public class InfrastructureCredentials {
     private String domain;
 
     private String subscriptionId;
-
-    private boolean allowSelfSignedSSLCertificate;
 }

--- a/src/main/java/org/ow2/proactive/connector/iaas/model/InfrastructureCredentials.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/model/InfrastructureCredentials.java
@@ -46,4 +46,6 @@ public class InfrastructureCredentials {
     private String domain;
 
     private String subscriptionId;
+
+    private boolean allowSelfSignedSSLCertificate;
 }

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientBuilderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientBuilderTest.java
@@ -1,0 +1,56 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.connector.iaas.cloud.provider.maas;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ow2.proactive.connector.iaas.cloud.provider.azure.AzureServiceBuilder;
+import org.ow2.proactive.connector.iaas.fixtures.InfrastructureFixture;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 12/03/17
+ */
+public class MaasProviderClientBuilderTest {
+
+    private MaasProviderClientBuilder maasProviderClientBuilder;
+
+    @Before
+    public void init() {
+        this.maasProviderClientBuilder = new MaasProviderClientBuilder();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testBuildServiceInstanceConnectionException() {
+        maasProviderClientBuilder.buildMaasClientFromInfrastructure(InfrastructureFixture.getMaasInfrastructure("id-maas",
+                                                                                                                "maas",
+                                                                                                                "apiToken",
+                                                                                                                "endpoint",
+                                                                                                                false));
+
+    }
+}

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientCacheTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/maas/MaasProviderClientCacheTest.java
@@ -1,0 +1,157 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.connector.iaas.cloud.provider.maas;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.ow2.proactive.connector.iaas.cloud.provider.azure.AzureServiceBuilder;
+import org.ow2.proactive.connector.iaas.cloud.provider.azure.AzureServiceCache;
+import org.ow2.proactive.connector.iaas.fixtures.InfrastructureFixture;
+import org.ow2.proactive.connector.iaas.model.Infrastructure;
+import org.ow2.proactive.connector.maas.MaasClient;
+
+import com.microsoft.azure.management.Azure;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 12/03/17
+ */
+public class MaasProviderClientCacheTest {
+
+    @InjectMocks
+    private MaasProviderClientCache maasProviderClientCache;
+
+    @Mock
+    private MaasProviderClientBuilder maasProviderClientBuilder;
+
+    @Mock
+    private MaasClient maasClient;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+        when(maasProviderClientBuilder.buildMaasClientFromInfrastructure(any(Infrastructure.class))).thenReturn(maasClient);
+    }
+
+    @Test
+    public void testGetServiceInstanceFirstTime() {
+        MaasClient maasClient = maasProviderClientCache.getMaasClient(InfrastructureFixture.getInfrastructure("id-maas",
+                                                                                                              "maas",
+                                                                                                              "endpoint",
+                                                                                                              null,
+                                                                                                              "apiToken"));
+        assertThat(maasClient, is(not(nullValue())));
+        verify(maasProviderClientBuilder,
+               times(1)).buildMaasClientFromInfrastructure(InfrastructureFixture.getInfrastructure("id-maas",
+                                                                                                   "maas",
+                                                                                                   "endpoint",
+                                                                                                   null,
+                                                                                                   "apiToken"));
+    }
+
+    @Test
+    public void testGetServiceInstanceManyTimeSameInfrastructure() {
+        maasProviderClientCache.getMaasClient(InfrastructureFixture.getInfrastructure("id-maas",
+                                                                                      "maas",
+                                                                                      "endpoint",
+                                                                                      null,
+                                                                                      "apiToken"));
+        maasProviderClientCache.getMaasClient(InfrastructureFixture.getInfrastructure("id-maas",
+                                                                                      "maas",
+                                                                                      "endpoint",
+                                                                                      null,
+                                                                                      "apiToken"));
+        maasProviderClientCache.getMaasClient(InfrastructureFixture.getInfrastructure("id-maas",
+                                                                                      "maas",
+                                                                                      "endpoint",
+                                                                                      null,
+                                                                                      "apiToken"));
+
+        verify(maasProviderClientBuilder,
+               times(1)).buildMaasClientFromInfrastructure(InfrastructureFixture.getInfrastructure("id-maas",
+                                                                                                   "maas",
+                                                                                                   "endpoint",
+                                                                                                   null,
+                                                                                                   "apiToken"));
+    }
+
+    @Test
+    public void testGetServiceInstanceDifferentInfrastructure() {
+        maasProviderClientCache.getMaasClient(InfrastructureFixture.getInfrastructure("id-maas",
+                                                                                      "maas",
+                                                                                      "endpoint",
+                                                                                      null,
+                                                                                      "apiToken"));
+        maasProviderClientCache.getMaasClient(InfrastructureFixture.getInfrastructure("id-maas-2",
+                                                                                      "maas",
+                                                                                      "endpoint",
+                                                                                      null,
+                                                                                      "apiToken"));
+
+        verify(maasProviderClientBuilder, times(2)).buildMaasClientFromInfrastructure(any(Infrastructure.class));
+    }
+
+    @Test
+    public void testRemoveServiceInstance() {
+        maasProviderClientCache.getMaasClient(InfrastructureFixture.getInfrastructure("id-maas",
+                                                                                      "maas",
+                                                                                      "endpoint",
+                                                                                      null,
+                                                                                      "apiToken"));
+
+        maasProviderClientCache.removeMaasClient(InfrastructureFixture.getInfrastructure("id-maas",
+                                                                                         "maas",
+                                                                                         "endpoint",
+                                                                                         null,
+                                                                                         "apiToken"));
+
+        maasProviderClientCache.getMaasClient(InfrastructureFixture.getInfrastructure("id-maas",
+                                                                                      "maas",
+                                                                                      "endpoint",
+                                                                                      null,
+                                                                                      "apiToken"));
+
+        verify(maasProviderClientBuilder,
+               times(2)).buildMaasClientFromInfrastructure(InfrastructureFixture.getInfrastructure("id-maas",
+                                                                                                   "maas",
+                                                                                                   "endpoint",
+                                                                                                   null,
+                                                                                                   "apiToken"));
+    }
+}

--- a/src/test/java/org/ow2/proactive/connector/iaas/fixtures/InfrastructureFixture.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/fixtures/InfrastructureFixture.java
@@ -47,6 +47,7 @@ public class InfrastructureFixture {
                                   null,
                                   null,
                                   null,
+                                  false,
                                   false);
     }
 
@@ -64,6 +65,7 @@ public class InfrastructureFixture {
                                   managementEndpoint,
                                   resourceManagerEndpoint,
                                   graphEndpoint,
+                                  false,
                                   false);
     }
 
@@ -92,6 +94,7 @@ public class InfrastructureFixture {
                                   null,
                                   null,
                                   null,
+                                  false,
                                   false);
     }
 
@@ -104,6 +107,7 @@ public class InfrastructureFixture {
                                   null,
                                   null,
                                   null,
+                                  false,
                                   removeOnShutdown);
     }
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/fixtures/InfrastructureFixture.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/fixtures/InfrastructureFixture.java
@@ -82,6 +82,21 @@ public class InfrastructureFixture {
                                   null,
                                   null,
                                   null,
+                                  false,
+                                  false);
+    }
+
+    public static Infrastructure getMaasInfrastructure(String name, String type, String apiToken, String endpoint,
+            boolean ignoreCertificateCheck) {
+        return new Infrastructure(name,
+                                  type,
+                                  endpoint,
+                                  CredentialsFixtures.getInfrastructureCredentials(null, apiToken, null, null),
+                                  null,
+                                  null,
+                                  null,
+                                  null,
+                                  ignoreCertificateCheck,
                                   false);
     }
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/fixtures/InstanceFixture.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/fixtures/InstanceFixture.java
@@ -76,6 +76,20 @@ public class InstanceFixture {
                             InstanceScriptFixture.getInstanceScript(scripts));
     }
 
+    public static Instance simpleInstanceWithResourcesAndInitScripts(String tag, String minRam, String minCpu,
+            String[] scripts) {
+        return new Instance("instanceId",
+                            tag,
+                            null,
+                            "1",
+                            null,
+                            HardwareFixtures.getHardware(minRam, minCpu),
+                            null,
+                            null,
+                            null,
+                            InstanceScriptFixture.getInstanceScript(scripts));
+    }
+
     public static Instance simpleInstanceWithMacAddress(String tag, String image, List<String> macAddresses) {
 
         return getInstanceWithMacAddress(tag,

--- a/src/test/java/org/ow2/proactive/connector/iaas/model/InfrastructureTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/model/InfrastructureTest.java
@@ -55,6 +55,7 @@ public class InfrastructureTest {
                                                            null,
                                                            null,
                                                            null,
+                                                           false,
                                                            false);
         assertThat(infrastructure.getId(), is("id-openstack"));
     }
@@ -70,6 +71,7 @@ public class InfrastructureTest {
                                                             null,
                                                             null,
                                                             null,
+                                                            false,
                                                             false);
         Infrastructure infrastructure2 = new Infrastructure("id-openstack",
                                                             "openstack",
@@ -80,6 +82,7 @@ public class InfrastructureTest {
                                                             null,
                                                             null,
                                                             null,
+                                                            false,
                                                             false);
 
         Set<Infrastructure> infrastructures = Sets.newHashSet(infrastructure1, infrastructure2);


### PR DESCRIPTION
# Implementation of the new MAAS (Metal as a Service) cloud infrastructure.

The new infrastructure essentially rely on the Java REST Client developped by ActiveEon: https://github.com/ow2-proactive/maas-rest-client.

*Note:* It is assumed that the machines to deploy are already registered to the MAAS region/rack controllers. Usually a first boot is enough to register new machines when controllers are configured with auto-discovery feature. New machines may need to be configured manually if the power parameters can not be retrieved automatically (eg. IPMI configuration). Once the machines are recognized by MAAS (systemId generated) they can be allocated, deployed, and released from the connector-iaas.

## For now, the deployment can be done in two different ways:

- The user provide the minimal amount of CPU and/or RAM desired for the new machines to deploy. If provided, the amount of instances will be used to deploy multiple machines if available.
- The user provide the systemId of the Machine to deploy. In this case the amount of instances to deploy and the minimal resources needed are ignored.

### Supported feature:
- Fully deploy machines in parallel: [Allocate -> Set tag -> Deploy -> Run script]
- Deploy from systemId
- Keep a cache of deployed machines on MAAS' side by using a specific tag
- Release single or all deployed machines
- Upload commissioning scripts

### Limitations:
- Tags' name must be unique, so multiple conenctor-iaas should have different tag names. The value is therefore useless and not used for filtering (it is worth noting that the tag name should be customized before using the connector).  

### Improvements:
- Add new filtering options for deployment
- Provide a list of systemId to deploy multiple Machines from their IDs
- Manage networking configuration (like fabrics, interfaces, etc.) in the future if needed 