### PR TITLE
Allow same script re-execution for Azure instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ smart-watch.iml
 *.log
 /out/*
 gradle/ext/
+*.iml
+/classes


### PR DESCRIPTION
Implement a workaround for the connector-iaas to be able to trigger a re-execution of a custom script when the script did not change from the previous run. The Azure provider blocks the re-execution of the same script when the configuration of the custom script extension does not change, so we add to all scripts a print command with a unique identifier to make sure they are always different.
Thus it is up to the connector-iaas to control the script executions and make sure they are not executed more times than necessary, because the Azure provider will not detect a duplicate script execution any more.