### PR TITLE
Fix AWS EC2 deployments from ProActive web interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,16 +123,16 @@ dependencies {
     // in the war/jar. When a war is loaded, the jars in the provided folder are not loaded.
     providedCompile 'org.springframework.boot:spring-boot-starter-jetty:1.3.1.RELEASE'
     // Jcloud dependencies
-    compile ('org.apache.jclouds:jclouds-compute:2.0.1'){
+    compile ('org.apache.stratos:jclouds-compute:1.9.1'){
         exclude module : 'jsr311-api'
     }
-    compile ('org.apache.jclouds.api:openstack-nova:2.0.1'){
+    compile ('org.apache.jclouds.api:openstack-nova:1.9.2'){
         exclude module : 'jsr311-api'
     }
-    compile ('org.apache.jclouds.provider:aws-ec2:2.0.1'){
+    compile ('org.apache.jclouds.provider:aws-ec2:1.9.1'){
         exclude module : 'jsr311-api'
     }
-    compile ('org.apache.jclouds.labs:docker:1.9.3'){
+    compile ('org.apache.jclouds.labs:docker:1.9.1'){
         exclude module : 'jsr311-api'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -123,16 +123,16 @@ dependencies {
     // in the war/jar. When a war is loaded, the jars in the provided folder are not loaded.
     providedCompile 'org.springframework.boot:spring-boot-starter-jetty:1.3.1.RELEASE'
     // Jcloud dependencies
-    compile ('org.apache.stratos:jclouds-compute:1.9.1'){
+    compile ('org.apache.jclouds:jclouds-compute:1.9.3'){
         exclude module : 'jsr311-api'
     }
-    compile ('org.apache.jclouds.api:openstack-nova:1.9.2'){
+    compile ('org.apache.jclouds.api:openstack-nova:1.9.3'){
         exclude module : 'jsr311-api'
     }
-    compile ('org.apache.jclouds.provider:aws-ec2:1.9.1'){
+    compile ('org.apache.jclouds.provider:aws-ec2:1.9.3'){
         exclude module : 'jsr311-api'
     }
-    compile ('org.apache.jclouds.labs:docker:1.9.1'){
+    compile ('org.apache.jclouds.labs:docker:1.9.3'){
         exclude module : 'jsr311-api'
     }
 

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsProvider.java
@@ -68,8 +68,6 @@ import lombok.Setter;
 @Component
 public abstract class JCloudsProvider implements CloudProvider {
 
-    private static final String DEFAULT_CONNECTOR_IAAS_VM_USER_LOGIN = "admin";
-
     private final Logger logger = Logger.getLogger(JCloudsProvider.class);
 
     @Autowired
@@ -78,9 +76,14 @@ public abstract class JCloudsProvider implements CloudProvider {
     @Autowired
     private TagManager tagManager;
 
+    /**
+     * By default, the login that will be used to connect to the instances
+     * and launch the script will be 'admin'. This default can be overriden
+     * in the application.properties file.
+     */
     @Getter
     @Setter
-    @Value("${connector-iaas.vm-user-login}")
+    @Value("${connector-iaas.vm-user-login:admin}")
     private String vmUserLogin;
 
     @Override
@@ -213,15 +216,14 @@ public abstract class JCloudsProvider implements CloudProvider {
     }
 
     private RunScriptOptions buildScriptOptions(InstanceScript instanceScript) {
-        logger.info("Script options: LoginUser=" + getVmUserLogin());
+        logger.info("Script options: userLogin=" + getVmUserLogin());
         return Optional.ofNullable(instanceScript.getCredentials())
                        .map(credentials -> RunScriptOptions.Builder.runAsRoot(false)
                                                                    .overrideLoginCredentials(new LoginCredentials.Builder().user(credentials.getUsername())
                                                                                                                            .password(credentials.getPassword())
                                                                                                                            .authenticateSudo(false)
                                                                                                                            .build()))
-                       .orElse(RunScriptOptions.Builder.overrideLoginUser(Optional.ofNullable(getVmUserLogin())
-                                                                                  .orElse(DEFAULT_CONNECTOR_IAAS_VM_USER_LOGIN)));
+                       .orElse(RunScriptOptions.Builder.overrideLoginUser(getVmUserLogin()));
     }
 
 }

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsProvider.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.log4j.Logger;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.ComputeMetadata;
 import org.jclouds.compute.domain.ExecResponse;
@@ -55,19 +56,32 @@ import org.ow2.proactive.connector.iaas.model.Network;
 import org.ow2.proactive.connector.iaas.model.ScriptResult;
 import org.ow2.proactive.connector.iaas.model.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Lists;
 
+import lombok.Getter;
+import lombok.Setter;
+
 
 @Component
 public abstract class JCloudsProvider implements CloudProvider {
+
+    private static final String DEFAULT_CONNECTOR_IAAS_VM_USER_LOGIN = "admin";
+
+    private final Logger logger = Logger.getLogger(JCloudsProvider.class);
 
     @Autowired
     private JCloudsComputeServiceCache jCloudsComputeServiceCache;
 
     @Autowired
     private TagManager tagManager;
+
+    @Getter
+    @Setter
+    @Value("${connector-iaas.vm-user-login}")
+    private String vmUserLogin;
 
     @Override
     public void deleteInstance(Infrastructure infrastructure, String instanceId) {
@@ -199,13 +213,15 @@ public abstract class JCloudsProvider implements CloudProvider {
     }
 
     private RunScriptOptions buildScriptOptions(InstanceScript instanceScript) {
+        logger.info("Script options: LoginUser=" + getVmUserLogin());
         return Optional.ofNullable(instanceScript.getCredentials())
                        .map(credentials -> RunScriptOptions.Builder.runAsRoot(false)
                                                                    .overrideLoginCredentials(new LoginCredentials.Builder().user(credentials.getUsername())
                                                                                                                            .password(credentials.getPassword())
                                                                                                                            .authenticateSudo(false)
                                                                                                                            .build()))
-                       .orElse(RunScriptOptions.NONE);
+                       .orElse(RunScriptOptions.Builder.overrideLoginUser(Optional.ofNullable(getVmUserLogin())
+                                                                                  .orElse(DEFAULT_CONNECTOR_IAAS_VM_USER_LOGIN)));
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 connector-iaas-tag.key = proactive-connector-iaas
 connector-iaas-tag.value = rZa/Qo,2eh+Fn5c!iqI9*ixSh7:K8x
+connector-iaas.vm-user-login = admin

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
@@ -111,7 +111,7 @@ public class AWSEC2JCloudsProviderTest {
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
-
+        jcloudsProvider.setVmUserLogin("ec2-user");
     }
 
     @Test

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
@@ -129,7 +129,7 @@ public class OpenstackJCloudsProviderTest {
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
-
+        jcloudsProvider.setVmUserLogin("user");
     }
 
     @Test


### PR DESCRIPTION
- downgrade jcloud dependency to be compliant with the GSON common dependency of jcloud and spring boot
- introduce configurable login user to run script on instances, used by jcloud-based deployments. Previously jcloud-based code tried to connect as root user, which is not allowed anymore on EC2 instances.
- align unit tests