### PR TITLE
Fix script re-execution in Azure infrastructure

### DIFF
--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/azure/AzureProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/azure/AzureProvider.java
@@ -618,12 +618,11 @@ public abstract class AzureProvider implements CloudProvider {
             // executed script.
             UUID scriptExecutionId = UUID.randomUUID();
             String concatenatedScriptsWithExecutionId = concatenatedScripts.insert(0,
-                                                                                   "echo \"Script execution ID: " +
-                                                                                      scriptExecutionId + "\"" +
+                                                                                   "echo script-ID" + SCRIPT_SEPARATOR +
+                                                                                      "echo " + scriptExecutionId +
                                                                                       SCRIPT_SEPARATOR)
                                                                            .toString();
-            logger.info("Request Azure provider to execute script " + scriptExecutionId + ": " +
-                        concatenatedScriptsWithExecutionId);
+            logger.info("Request Azure provider to execute script: " + concatenatedScriptsWithExecutionId);
             vm.update()
               .updateExtension(vmExtension.get().name())
               .withPublicSetting(SCRIPT_EXTENSION_CMD_KEY, concatenatedScriptsWithExecutionId)


### PR DESCRIPTION
- when an instance executes a script for the second time or more, an unique id is echoed. But this echo command was containing double quotes which could lead to command injection or command mess. This commit fixes this by removing double quotes in the script. Note that we need to keep the unique identifier in the script otherwise an identical script will not be re-executed by Azure.