### PR TITLE
fix: stored infrastructures should be synchronized

### DIFF
--- a/src/main/java/org/ow2/proactive/connector/iaas/cache/InfrastructureCache.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cache/InfrastructureCache.java
@@ -45,14 +45,14 @@ public class InfrastructureCache {
         this.supportedInfrastructures = ImmutableMap.of();
     }
 
-    public void registerInfrastructure(Infrastructure infrastructure) {
+    public synchronized void registerInfrastructure(Infrastructure infrastructure) {
         Map<String, Infrastructure> tempInfrastructures = cloneSupportedInfrastructures();
 
         tempInfrastructures.put(infrastructure.getId(), infrastructure);
         supportedInfrastructures = ImmutableMap.copyOf(tempInfrastructures);
     }
 
-    public void deleteInfrastructure(Infrastructure infrastructure) {
+    public synchronized void deleteInfrastructure(Infrastructure infrastructure) {
         Map<String, Infrastructure> tempInfrastructures = cloneSupportedInfrastructures();
 
         tempInfrastructures.remove(infrastructure.getId());


### PR DESCRIPTION
The stored infrastructures should be synchronized to avoid conflict writing.  
A typical usecase: we may have multiple infrastructures to recover concurrently during RM server startup.