### PR TITLE
fix: link created instances to the infrastructure

### DIFF
--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/TagManager.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/TagManager.java
@@ -46,31 +46,44 @@ public class TagManager {
 
     private static final String DEFAULT_CONNECTOR_IAAS_TAG_VALUE = "default-tag";
 
+    private static final String DEFAULT_INFRASTRUCTURE_ID_TAG_KEY = "proactive-infrastructure-id";
+
     @Getter
     private final Tag connectorIaasTag;
 
+    @Getter
+    private final Tag infrastructureIdTag;
+
     @Autowired
     public TagManager(@Value("${connector-iaas-tag.key}") String connectorIaasTagKey,
-            @Value("${connector-iaas-tag.value}") String connectorIaasTagValue) {
+            @Value("${connector-iaas-tag.value}") String connectorIaasTagValue,
+            @Value("${infrastructure-id-tag.key}") String infrastructureIdTagKey) {
         connectorIaasTag = Tag.builder()
                               .key(Optional.ofNullable(connectorIaasTagKey).orElse(DEFAULT_CONNECTOR_IAAS_TAG_KEY))
                               .value(Optional.ofNullable(connectorIaasTagValue)
                                              .orElse(DEFAULT_CONNECTOR_IAAS_TAG_VALUE))
                               .build();
+        infrastructureIdTag = Tag.builder()
+                                 .key(Optional.ofNullable(infrastructureIdTagKey)
+                                              .orElse(DEFAULT_INFRASTRUCTURE_ID_TAG_KEY))
+                                 .build();
     }
 
     /**
-     * Collect tags and ensure that mandatory connector-iaas tag key is not duplicated
+     * Collect tags and ensure that mandatory tags key connector-iaas and infrastructure-id are not duplicated
      *
      * @param instanceOptions   instance's options that may contain tags
      * @return  the list of all tags
      */
-    public List<Tag> retrieveAllTags(Options instanceOptions) {
+    public List<Tag> retrieveAllTags(String infrastructureId, Options instanceOptions) {
+        infrastructureIdTag.setValue(infrastructureId);
         List<Tag> tags = new ArrayList<>();
         tags.add(connectorIaasTag);
+        tags.add(infrastructureIdTag);
         Optional.ofNullable(instanceOptions).map(Options::getTags).ifPresent(optionalTags -> {
             tags.addAll(optionalTags.stream()
                                     .filter(optionalTag -> !optionalTag.getKey().equals(connectorIaasTag.getKey()))
+                                    .filter(optionalTag -> !optionalTag.getKey().equals(infrastructureIdTag.getKey()))
                                     .collect(Collectors.toList()));
         });
         return tags;

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/azure/AzureProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/azure/AzureProvider.java
@@ -250,7 +250,8 @@ public class AzureProvider implements CloudProvider {
                                                                                                                                                                                region,
                                                                                                                                                                                networkOptions,
                                                                                                                                                                                instanceNumber);
-                                                                                return prepareVirtualMachine(instance,
+                                                                                return prepareVirtualMachine(infrastructure.getId(),
+                                                                                                             instance,
                                                                                                              azureService,
                                                                                                              resourceGroup,
                                                                                                              region,
@@ -313,9 +314,9 @@ public class AzureProvider implements CloudProvider {
         return Optional.ofNullable(azureService.virtualMachineCustomImages().getById(id));
     }
 
-    protected Creatable<VirtualMachine> prepareVirtualMachine(Instance instance, Azure azureService,
-            ResourceGroup resourceGroup, Region region, String instanceTag, VirtualMachineCustomImage image,
-            Creatable<NetworkInterface> creatableNetworkInterface) {
+    protected Creatable<VirtualMachine> prepareVirtualMachine(String infrastructureId, Instance instance,
+            Azure azureService, ResourceGroup resourceGroup, Region region, String instanceTag,
+            VirtualMachineCustomImage image, Creatable<NetworkInterface> creatableNetworkInterface) {
 
         // Configure the VM depending on the OS type
         VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged creatableVirtualMachineWithImage;
@@ -376,7 +377,7 @@ public class AzureProvider implements CloudProvider {
         });
 
         // Set tags
-        return creatableVMWithSize.withTags(tagManager.retrieveAllTags(instance.getOptions())
+        return creatableVMWithSize.withTags(tagManager.retrieveAllTags(infrastructureId, instance.getOptions())
                                                       .stream()
                                                       .collect(Collectors.toMap(Tag::getKey, Tag::getValue)));
     }

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsProvider.java
@@ -109,13 +109,18 @@ public abstract class JCloudsProvider implements CloudProvider {
     @Override
     public Set<Instance> getCreatedInfrastructureInstances(Infrastructure infrastructure) {
         Tag connectorIaasTag = tagManager.getConnectorIaasTag();
+        Tag infrastructureIdTag = tagManager.getInfrastructureIdTag();
         return createInstancesFromNodes(getAllNodes(infrastructure).stream()
                                                                    .filter(node -> node.getUserMetadata()
-                                                                                       .keySet()
-                                                                                       .contains(connectorIaasTag.getKey()) &&
+                                                                                       .containsKey(connectorIaasTag.getKey()) &&
                                                                                    node.getUserMetadata()
                                                                                        .get(connectorIaasTag.getKey())
-                                                                                       .equals(connectorIaasTag.getValue()))
+                                                                                       .equals(connectorIaasTag.getValue()) &&
+                                                                                   node.getUserMetadata()
+                                                                                       .containsKey(infrastructureIdTag.getKey()) &&
+                                                                                   node.getUserMetadata()
+                                                                                       .get(infrastructureIdTag.getKey())
+                                                                                       .equals(infrastructure.getId()))
                                                                    .collect(Collectors.toSet()));
     }
 

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProvider.java
@@ -101,7 +101,7 @@ public class AWSEC2JCloudsProvider extends JCloudsProvider {
         Optional.ofNullable(instance.getOptions()).ifPresent(options -> addOptions(template, options));
 
         // Add tags
-        addTags(template, tagManager.retrieveAllTags(instance.getOptions()));
+        addTags(template, tagManager.retrieveAllTags(infrastructure.getId(), instance.getOptions()));
 
         addCredential(template,
                       Optional.ofNullable(instance.getCredentials())

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/google/GCEJCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/google/GCEJCloudsProvider.java
@@ -95,7 +95,7 @@ public class GCEJCloudsProvider extends JCloudsProvider {
                                                                         .as(GoogleComputeEngineTemplateOptions.class);
 
         // Add the tag key connector-iaas to mark the instance as a createdInstance managed by ProActive
-        gceTemplateOptions.userMetadata(tagManager.retrieveAllTags(instance.getOptions())
+        gceTemplateOptions.userMetadata(tagManager.retrieveAllTags(infrastructure.getId(), instance.getOptions())
                                                   .stream()
                                                   .collect(Collectors.toMap(Tag::getKey, Tag::getValue)));
 

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProvider.java
@@ -121,7 +121,7 @@ public class OpenstackJCloudsProvider extends JCloudsProvider {
         }
 
         // Set tags before returning options
-        return createServerOptions.metadata(tagManager.retrieveAllTags(instance.getOptions())
+        return createServerOptions.metadata(tagManager.retrieveAllTags(infrastructure.getId(), instance.getOptions())
                                                       .stream()
                                                       .collect(Collectors.toMap(Tag::getKey, Tag::getValue)));
     }

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/vmware/VMWareProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/vmware/VMWareProvider.java
@@ -102,7 +102,7 @@ public class VMWareProvider implements CloudProvider {
         Folder destinationFolder = getDestinationFolderFromImage(image, rootFolder);
         VirtualMachine vmToClone = getVirtualMachineByNameOrUUID(instanceImageId, rootFolder);
 
-        List<Tag> tags = tagManager.retrieveAllTags(instance.getOptions());
+        List<Tag> tags = tagManager.retrieveAllTags(infrastructure.getId(), instance.getOptions());
 
         return IntStream.rangeClosed(1, Integer.valueOf(instance.getNumber())).mapToObj(instanceIndexStartAt1 -> {
             String uniqueInstanceTag = createUniqueInstanceTag(instance.getTag(), instanceIndexStartAt1);

--- a/src/main/java/org/ow2/proactive/connector/iaas/model/Tag.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/model/Tag.java
@@ -25,12 +25,7 @@
  */
 package org.ow2.proactive.connector.iaas.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 
 @EqualsAndHashCode
@@ -43,6 +38,7 @@ public class Tag {
 
     private String key;
 
+    @Setter
     private String value;
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@
 #==========================================================================
 connector-iaas-tag.key = proactive-connector-iaas
 connector-iaas-tag.value = rZa/Qo,2eh+Fn5c!iqI9*ixSh7:K8x
+infrastructure-id-tag.key = proactive-infrastructure-id
 connector-iaas.vm-user-login = admin
 
 connector-iaas.jclouds.request-timeout=10000

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/TagManagerTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/TagManagerTest.java
@@ -26,8 +26,7 @@
 package org.ow2.proactive.connector.iaas.cloud;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,38 +43,44 @@ public class TagManagerTest {
 
     @Before
     public void init() {
-        tagManager = new TagManager("connector-iaas-tag", "default-value");
+        tagManager = new TagManager("connector-iaas-tag", "default-value", "infrastructure-id-tag");
     }
 
     @Test
     public void testRetrieveTagsWithoutOptions() {
-        List<Tag> tags = tagManager.retrieveAllTags(null);
-        assertTrue(tags.size() == 1);
+        List<Tag> tags = tagManager.retrieveAllTags(null, null);
+        assertTrue(tags.size() == 2);
         assertThat(tags.get(0).getKey(), is("connector-iaas-tag"));
         assertThat(tags.get(0).getValue(), is("default-value"));
+        assertThat(tags.get(1).getKey(), is("infrastructure-id-tag"));
     }
 
     @Test
     public void testRetrieveTagsWithUniqueOptions() {
+        final String infrastructureId = "infra-id";
         List<Tag> optionsTags = new ArrayList<>();
         optionsTags.add(Tag.builder().key("random-tag1").value("random-value1").build());
         optionsTags.add(Tag.builder().key("random-tag2").value("random-value2").build());
         optionsTags.add(Tag.builder().key("random-tag3").value("random-value3").build());
         Options options = Options.builder().tags(optionsTags).build();
-        List<Tag> tags = tagManager.retrieveAllTags(options);
-        assertTrue(tags.size() == 4);
+        List<Tag> tags = tagManager.retrieveAllTags(infrastructureId, options);
+        assertTrue(tags.size() == 5);
     }
 
     @Test
     public void testRetrieveTagsWithDuplicatedMandatoryKey() {
+        final String infrastructureId = "infra-id";
         List<Tag> optionsTags = new ArrayList<>();
         optionsTags.add(Tag.builder().key("connector-iaas-tag").value("new-default-value").build());
         optionsTags.add(Tag.builder().key("random-tag").value("random-value").build());
+        optionsTags.add(Tag.builder().key("infrastructure-id-tag").value("new-infra-id-value").build());
         Options options = Options.builder().tags(optionsTags).build();
-        List<Tag> tags = tagManager.retrieveAllTags(options);
-        assertTrue(tags.size() == 2);
+        List<Tag> tags = tagManager.retrieveAllTags(infrastructureId, options);
+        assertTrue(tags.size() == 3);
         assertThat(tags.stream().filter(tag -> tag.getKey().equals("connector-iaas-tag")).findAny().get().getValue(),
                    is("default-value"));
+        assertThat(tags.stream().filter(tag -> tag.getKey().equals("infrastructure-id-tag")).findAny().get().getValue(),
+                   is("infra-id"));
     }
 
 }

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/azure/AzureProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/azure/AzureProviderTest.java
@@ -366,7 +366,8 @@ public class AzureProviderTest {
         when(virtualMachineCreatedResources.values()).thenReturn(createdVirtualMachines);
 
         // Tags
-        when(tagManager.retrieveAllTags(any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
+        when(tagManager.retrieveAllTags(anyString(),
+                                        any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
 
         // Tests
         Infrastructure infrastructure;
@@ -520,7 +521,8 @@ public class AzureProviderTest {
         when(virtualMachineCreatedResources.values()).thenReturn(createdVirtualMachines);
 
         // Tags
-        when(tagManager.retrieveAllTags(any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
+        when(tagManager.retrieveAllTags(anyString(),
+                                        any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
 
         // Tests
         Infrastructure infrastructure;

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
@@ -31,6 +31,7 @@ import static org.jclouds.scriptbuilder.domain.Statements.exec;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -174,7 +175,8 @@ public class AWSEC2JCloudsProviderTest {
         when(templateOptions.as(AWSEC2TemplateOptions.class)).thenReturn(awsEC2TemplateOptions);
 
         // Tags
-        when(tagManager.retrieveAllTags(any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
+        when(tagManager.retrieveAllTags(anyString(),
+                                        any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
 
         Set<Instance> created = jcloudsProvider.createInstance(infratructure, instance);
 
@@ -248,7 +250,8 @@ public class AWSEC2JCloudsProviderTest {
         when(templateOptions.as(AWSEC2TemplateOptions.class)).thenReturn(awsEC2TemplateOptions);
 
         // Tags
-        when(tagManager.retrieveAllTags(any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
+        when(tagManager.retrieveAllTags(anyString(),
+                                        any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
 
         Set<Instance> created = jcloudsProvider.createInstance(infratructure, instance);
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/google/GCEJCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/google/GCEJCloudsProviderTest.java
@@ -30,8 +30,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Answers.RETURNS_SELF;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -74,6 +73,8 @@ import com.google.common.collect.Sets;
  */
 public class GCEJCloudsProviderTest {
     private static final String TYPE = "google-compute-engine";
+
+    private static final String INFRA_ID = "id-google-compute-engine";
 
     private static final String INSTANCE_GROUP = "instance-group";
 
@@ -143,7 +144,7 @@ public class GCEJCloudsProviderTest {
 
     @Test
     public void testCreateInstance() {
-        Infrastructure infrastructure = InfrastructureFixture.getSimpleInfrastructure(TYPE);
+        Infrastructure infrastructure = InfrastructureFixture.getSimpleInfrastructure(INFRA_ID, TYPE);
 
         Instance instance = InstanceFixture.getInstanceWithInitScript(INSTANCE_GROUP,
                                                                       IMAGE,
@@ -161,7 +162,8 @@ public class GCEJCloudsProviderTest {
         when(templateBuilder.build()).thenReturn(template);
         when(template.getOptions()).thenReturn(templateOptions);
         when(templateOptions.as(GoogleComputeEngineTemplateOptions.class)).thenReturn(gceTemplateOptions);
-        when(tagManager.retrieveAllTags(any(Options.class))).thenReturn(Lists.newArrayList(CONNECTOR_IAAS_TAG));
+        when(tagManager.retrieveAllTags(anyString(),
+                                        any(Options.class))).thenReturn(Lists.newArrayList(CONNECTOR_IAAS_TAG));
 
         Set<Instance> createdInstances = gceJCloudsProvider.createInstance(infrastructure, instance);
 
@@ -196,7 +198,7 @@ public class GCEJCloudsProviderTest {
         when(templateBuilder.build()).thenReturn(template);
         when(template.getOptions()).thenReturn(templateOptions);
         when(templateOptions.as(GoogleComputeEngineTemplateOptions.class)).thenReturn(gceTemplateOptions);
-        when(tagManager.retrieveAllTags(any())).thenReturn(Lists.newArrayList(CONNECTOR_IAAS_TAG));
+        when(tagManager.retrieveAllTags(anyString(), any())).thenReturn(Lists.newArrayList(CONNECTOR_IAAS_TAG));
 
         Set<Instance> createdInstances = gceJCloudsProvider.createInstance(infrastructure, instance);
 
@@ -243,7 +245,7 @@ public class GCEJCloudsProviderTest {
         when(templateBuilder.build()).thenReturn(template);
         when(template.getOptions()).thenReturn(templateOptions);
         when(templateOptions.as(GoogleComputeEngineTemplateOptions.class)).thenReturn(gceTemplateOptions);
-        when(tagManager.retrieveAllTags(any())).thenReturn(Lists.newArrayList(CONNECTOR_IAAS_TAG));
+        when(tagManager.retrieveAllTags(anyString(), any())).thenReturn(Lists.newArrayList(CONNECTOR_IAAS_TAG));
 
         Set<Instance> createdInstances = gceJCloudsProvider.createInstance(infrastructure, instance);
 
@@ -287,7 +289,8 @@ public class GCEJCloudsProviderTest {
         when(templateBuilder.build()).thenReturn(template);
         when(template.getOptions()).thenReturn(templateOptions);
         when(templateOptions.as(GoogleComputeEngineTemplateOptions.class)).thenReturn(gceTemplateOptions);
-        when(tagManager.retrieveAllTags(any(Options.class))).thenReturn(Lists.newArrayList(CONNECTOR_IAAS_TAG));
+        when(tagManager.retrieveAllTags(anyString(),
+                                        any(Options.class))).thenReturn(Lists.newArrayList(CONNECTOR_IAAS_TAG));
 
         when(computeService.createNodesInGroup(INSTANCE_GROUP,
                                                INSTANCE_NUM,

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
@@ -191,7 +191,8 @@ public class OpenstackJCloudsProviderTest {
         when(computeService.listNodes()).thenReturn(nodes);
 
         // Tags
-        when(tagManager.retrieveAllTags(any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
+        when(tagManager.retrieveAllTags(anyString(),
+                                        any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
 
         when(computeService.createNodesInGroup(instance.getTag(),
                                                Integer.parseInt(instance.getNumber()),
@@ -243,7 +244,8 @@ public class OpenstackJCloudsProviderTest {
         when(serverApi.create(anyString(), anyString(), anyString(), anyObject())).thenReturn(serverCreated);
 
         // Tags
-        when(tagManager.retrieveAllTags(any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
+        when(tagManager.retrieveAllTags(anyString(),
+                                        any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
 
         Set nodesMetaData = Sets.newHashSet();
         NodeMetadataImpl nodeMetadataImpl = mock(NodeMetadataImpl.class);

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/vmware/VMWareProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/vmware/VMWareProviderTest.java
@@ -201,7 +201,8 @@ public class VMWareProviderTest {
         when(task.waitForTask()).thenReturn(Task.SUCCESS);
 
         // Tags
-        when(tagManager.retrieveAllTags(any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
+        when(tagManager.retrieveAllTags(anyString(),
+                                        any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
 
         Set<Instance> createdInstances = vmWareProvider.createInstance(infrastructure, instance);
 
@@ -258,7 +259,8 @@ public class VMWareProviderTest {
         when(task.waitForTask()).thenReturn(Task.SUCCESS);
 
         // Tags
-        when(tagManager.retrieveAllTags(any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
+        when(tagManager.retrieveAllTags(anyString(),
+                                        any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
 
         // Create the new instance and check if the MAC address is set as option
         Set<Instance> createdInstances = vmWareProvider.createInstance(infrastructure, instance);
@@ -305,7 +307,8 @@ public class VMWareProviderTest {
         when(task.waitForTask()).thenReturn(Task.SUCCESS);
 
         // Tags
-        when(tagManager.retrieveAllTags(any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
+        when(tagManager.retrieveAllTags(anyString(),
+                                        any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
 
         Set<Instance> createdInstances = vmWareProvider.createInstance(infrastructure, instance);
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/fixtures/InfrastructureFixture.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/fixtures/InfrastructureFixture.java
@@ -127,6 +127,21 @@ public class InfrastructureFixture {
                                   null);
     }
 
+    public static Infrastructure getSimpleInfrastructure(String id, String type) {
+        return new Infrastructure(id,
+                                  type,
+                                  "endPoint",
+                                  CredentialsFixtures.getInfrastructureCredentials("userName", "password"),
+                                  null,
+                                  null,
+                                  null,
+                                  null,
+                                  false,
+                                  null,
+                                  null,
+                                  null);
+    }
+
     public static Infrastructure getSimpleInfrastructure(String type, boolean removeOnShutdown) {
         return new Infrastructure("id-" + type,
                                   type,


### PR DESCRIPTION
When retrieving createdInstances, only the instances created through the specific infrastructure should be returned.

This PR is supposed to fix the problem: when two infrastructures use the same credentials to the cloud platform, the request of `getCreatedInstances(infraId)` and `deleteInfrastructureWithCreatedInstances(infraId)` get/delete all the instances created through both two infrastructures.

The idea of this fix is to store `infrastructureId` as a tag in each created instance.

Changes:
- In `TagManager.retrieveAllTags`, add tag `proactive-infrastructure-id` (key configurable through `infrastructure-id-tag.key`) for storing the infrastructure id in each created instances
- filter out the instances match the infrastructureId in `JCloudsProvider.getCreatedInfrastructureInstances`

Notice:
We may also need to filter out `getCreatedInfrastructureInstances` for `AzureProvider` and `VMWareProvider`. As I'm not familiar with these two connectors, it's not modified for the moment.
