### PR TITLE
change concatenating tool to remove ending semicolon

### DIFF
--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/azure/AzureProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/azure/AzureProvider.java
@@ -25,12 +25,8 @@
  */
 package org.ow2.proactive.connector.iaas.cloud.provider.azure;
 
+import java.util.*;
 import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -351,9 +347,9 @@ public class AzureProvider implements CloudProvider {
         // Add init script(s) using dedicated Microsoft extension
         Optional.ofNullable(instance.getInitScript()).map(InstanceScript::getScripts).ifPresent(scripts -> {
             if (scripts.length > 0) {
-                StringBuilder concatenatedScripts = new StringBuilder();
+                StringJoiner concatenatedScripts = new StringJoiner(SCRIPT_SEPARATOR);
                 Lists.newArrayList(scripts)
-                     .forEach(script -> concatenatedScripts.append(script).append(SCRIPT_SEPARATOR));
+                     .forEach(script -> concatenatedScripts.add(script));
                 if (operatingSystemType.equals(OperatingSystemTypes.LINUX)) {
                     creatableVMWithSize.defineNewExtension(createUniqueScriptName(instanceTag))
                                        .withPublisher(SCRIPT_EXTENSION_PUBLISHER_LINUX)
@@ -721,9 +717,9 @@ public class AzureProvider implements CloudProvider {
     protected List<ScriptResult> executeScriptOnVM(VirtualMachine vm, InstanceScript instanceScript) {
 
         // Concatenate all provided scripts in one (Multiple VMExtensions per handler not supported)
-        StringBuilder concatenatedScripts = new StringBuilder();
+        StringJoiner concatenatedScripts = new StringJoiner(SCRIPT_SEPARATOR);
         Arrays.stream(instanceScript.getScripts()).forEach(script -> {
-            concatenatedScripts.append(script).append(SCRIPT_SEPARATOR);
+            concatenatedScripts.add(script);
         });
 
         // Update existing or install new extension

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/azure/AzureProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/azure/AzureProvider.java
@@ -25,8 +25,13 @@
  */
 package org.ow2.proactive.connector.iaas.cloud.provider.azure;
 
-import java.util.*;
 import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -348,8 +353,7 @@ public class AzureProvider implements CloudProvider {
         Optional.ofNullable(instance.getInitScript()).map(InstanceScript::getScripts).ifPresent(scripts -> {
             if (scripts.length > 0) {
                 StringJoiner concatenatedScripts = new StringJoiner(SCRIPT_SEPARATOR);
-                Lists.newArrayList(scripts)
-                     .forEach(script -> concatenatedScripts.add(script));
+                Lists.newArrayList(scripts).forEach(script -> concatenatedScripts.add(script));
                 if (operatingSystemType.equals(OperatingSystemTypes.LINUX)) {
                     creatableVMWithSize.defineNewExtension(createUniqueScriptName(instanceTag))
                                        .withPublisher(SCRIPT_EXTENSION_PUBLISHER_LINUX)


### PR DESCRIPTION
Old StringBuilder was adding a semicolon `;` at the end of the set of strings, causing an error when booting the VM