### PR TITLE
Fix aws-ec2 jClouds connector

### DIFF
--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsComputeServiceBuilder.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsComputeServiceBuilder.java
@@ -67,10 +67,10 @@ public class JCloudsComputeServiceBuilder {
     @Value("${connector-iaas.openstack.jclouds.compute.timeout.script-complete:60000}")
     private String timeoutScriptComplete;
 
-    @Value("${connector-iaas.aws.jclouds.ssh.max-retries:100}")
+    @Value("${connector-iaas.aws.jclouds.ssh.max-retries:7}")
     private String sshMaxRetries;
 
-    @Value("${connector-iaas.aws.jclouds.max-retries:1000}")
+    @Value("${connector-iaas.aws.jclouds.max-retries:5}")
     private String maxRetries;
 
     @Autowired

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProvider.java
@@ -94,6 +94,7 @@ public class AWSEC2JCloudsProvider extends JCloudsProvider {
                                                         .minRam(Integer.parseInt(instance.getHardware().getMinRam()))
                                                         .minCores(Double.parseDouble(instance.getHardware()
                                                                                              .getMinCores()))
+                                                        .locationId(getRegionFromImage(instance))
                                                         .imageId(instance.getImage());
 
         Template template = templateBuilder.build();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,5 +31,5 @@ connector-iaas.openstack.jclouds.compute.timeout.script-complete=60000
 #==========================================================================
 #***********************AWS connector properties***************************
 #==========================================================================
-connector-iaas.aws.jclouds.ssh.max-retries=100
-connector-iaas.aws.jclouds.max-retries=1000
+connector-iaas.aws.jclouds.ssh.max-retries=7
+connector-iaas.aws.jclouds.max-retries=5

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
@@ -86,6 +86,10 @@ import jersey.repackaged.com.google.common.collect.Sets;
 
 public class AWSEC2JCloudsProviderTest {
 
+    private static final String REGION = "region";
+
+    private static final String IMAGE = REGION + "/ami-image";
+
     @InjectMocks
     private AWSEC2JCloudsProvider jcloudsProvider;
 
@@ -135,7 +139,7 @@ public class AWSEC2JCloudsProviderTest {
 
         Instance instance = InstanceFixture.getInstance("instance-id",
                                                         "instance-name",
-                                                        "image",
+                                                        IMAGE,
                                                         "2",
                                                         "512",
                                                         "2",
@@ -147,6 +151,8 @@ public class AWSEC2JCloudsProviderTest {
 
         when(templateBuilder.minCores(Double.parseDouble(instance.getHardware()
                                                                  .getMinCores()))).thenReturn(templateBuilder);
+
+        when(templateBuilder.locationId(REGION)).thenReturn(templateBuilder);
 
         when(templateBuilder.imageId(instance.getImage())).thenReturn(templateBuilder);
 
@@ -208,7 +214,7 @@ public class AWSEC2JCloudsProviderTest {
 
         Instance instance = InstanceFixture.getInstanceWithSpotPrice("instance-id",
                                                                      "instance-name",
-                                                                     "image",
+                                                                     IMAGE,
                                                                      "2",
                                                                      "512",
                                                                      "2",
@@ -221,6 +227,8 @@ public class AWSEC2JCloudsProviderTest {
 
         when(templateBuilder.minCores(Double.parseDouble(instance.getHardware()
                                                                  .getMinCores()))).thenReturn(templateBuilder);
+
+        when(templateBuilder.locationId(REGION)).thenReturn(templateBuilder);
 
         when(templateBuilder.imageId(instance.getImage())).thenReturn(templateBuilder);
 
@@ -285,7 +293,7 @@ public class AWSEC2JCloudsProviderTest {
 
         Instance instance = InstanceFixture.getInstance("instance-id",
                                                         "instance-name",
-                                                        "image",
+                                                        IMAGE,
                                                         "2",
                                                         "512",
                                                         "1",
@@ -297,6 +305,8 @@ public class AWSEC2JCloudsProviderTest {
 
         when(templateBuilder.minCores(Double.parseDouble(instance.getHardware()
                                                                  .getMinCores()))).thenReturn(templateBuilder);
+
+        when(templateBuilder.locationId(REGION)).thenReturn(templateBuilder);
 
         when(templateBuilder.imageId(instance.getImage())).thenReturn(templateBuilder);
 
@@ -365,7 +375,7 @@ public class AWSEC2JCloudsProviderTest {
 
         Instance instance = InstanceFixture.getInstanceWithSecurityGroup("instance-id",
                                                                          "instance-name",
-                                                                         "image",
+                                                                         IMAGE,
                                                                          "2",
                                                                          "512",
                                                                          "2",
@@ -378,6 +388,8 @@ public class AWSEC2JCloudsProviderTest {
 
         when(templateBuilder.minCores(Double.parseDouble(instance.getHardware()
                                                                  .getMinCores()))).thenReturn(templateBuilder);
+
+        when(templateBuilder.locationId(REGION)).thenReturn(templateBuilder);
 
         when(templateBuilder.imageId(instance.getImage())).thenReturn(templateBuilder);
 
@@ -438,7 +450,7 @@ public class AWSEC2JCloudsProviderTest {
 
         Instance instance = InstanceFixture.getInstanceWithSubnetId("instance-id",
                                                                     "instance-name",
-                                                                    "image",
+                                                                    IMAGE,
                                                                     "2",
                                                                     "512",
                                                                     "2",
@@ -451,6 +463,8 @@ public class AWSEC2JCloudsProviderTest {
 
         when(templateBuilder.minCores(Double.parseDouble(instance.getHardware()
                                                                  .getMinCores()))).thenReturn(templateBuilder);
+
+        when(templateBuilder.locationId(REGION)).thenReturn(templateBuilder);
 
         when(templateBuilder.imageId(instance.getImage())).thenReturn(templateBuilder);
 


### PR DESCRIPTION
- set region (locationId) for the aws instances, so that the user can get correct information when they request an unsupported region.
- reduce the configuration of jclouds max-retries.