### PR TITLE
Add Openstack domain name configuration to ensure no auth pb

### DIFF
--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackUtil.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackUtil.java
@@ -73,6 +73,11 @@ public class OpenstackUtil {
             String value = infrastructure.getScope().getValue();
 
             properties.put(KeystoneProperties.SCOPE, prefix + SEPARATOR + value);
+
+            if (infrastructure.getCredentials().getDomain() != null &&
+                !infrastructure.getCredentials().getDomain().isEmpty()) {
+                properties.put(KeystoneProperties.PROJECT_DOMAIN_NAME, infrastructure.getCredentials().getDomain());
+            }
             log.info("Using Openstack infrastructure with scope: " + prefix + SEPARATOR + value);
 
         }


### PR DESCRIPTION
Fix the "resource not found" issue for keystone v3 auth which sometimes happen on specific platforms.