### PR TITLE
AzureProvider: add support for known images

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,8 +230,8 @@ dependencies {
     compile 'com.toastcoders:yavijava:6.0.04'
 
     // Microsoft Azure
-    compile 'com.microsoft.azure:azure:1.35.1'
-    compile 'com.microsoft.azure:azure-mgmt-network:1.35.1'
+    compile 'com.microsoft.azure:azure:1.41.3'
+    compile 'com.microsoft.azure:azure-mgmt-network:1.41.3'
 
     // AWS Pricing
     compile group: 'software.amazon.awssdk', name: 'pricing', version: '2.17.95'


### PR DESCRIPTION
 - when an image name is provided, a corresponding known image will first be searched before looking for a custom image
 - also, upgraded azure sdk version