### PR TITLE
Upgrade jcloud and gson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ dependencies {
     compile("org.springframework:spring-web:${springVersion}")
     compile("org.springframework:spring-webmvc:${springVersion}")
 
-    def jcloudsVersion = "2.1.3"
+    def jcloudsVersion = "2.4.0"
 
     // Jcloud dependencies
     compile ("org.apache.jclouds:jclouds-compute:${jcloudsVersion}"){
@@ -270,7 +270,7 @@ dependencies {
     compile 'org.json:json:20151123'
 
     // Gson dependency
-    compile 'com.google.code.gson:gson:2.5'
+    compile 'com.google.code.gson:gson:2.8.0'
 
     //Logger
     compile 'org.apache.logging.log4j:log4j-api:2.17.1'


### PR DESCRIPTION
Upgrade of guava created an incompatibility with some usage of it inside jclouds (NoSuchMethodError).

Upgrading jclouds should remove this incompatibility (though it may create other issues)