### PR TITLE
Iaas quality improvements

### DIFF
--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsComputeServiceBuilder.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsComputeServiceBuilder.java
@@ -92,6 +92,9 @@ public class JCloudsComputeServiceBuilder {
 
         String identityPrefix = StringUtils.isNotBlank(domain) ? (domain + ":") : "";
 
+        log.info("Building ComputeService for infrastructureID: " + infrastructure.getId());
+        log.info("Using credentials: " + identityPrefix + infrastructure.getCredentials().getUsername());
+
         ContextBuilder contextBuilder = ContextBuilder.newBuilder(infrastructure.getType())
                                                       .credentials(identityPrefix +
                                                                    infrastructure.getCredentials().getUsername(),
@@ -103,14 +106,20 @@ public class JCloudsComputeServiceBuilder {
                 .filter(endPoint -> !endPoint.isEmpty())
                 .ifPresent(endPoint -> contextBuilder.endpoint(endPoint));
 
+        log.info("ContextBuilder configuration complete, building ComputeServiceContext...");
+
         ComputeServiceContext context = contextBuilder.buildView(ComputeServiceContext.class);
+
+        log.info("ComputeServiceContext built successfully: " + context.toString());
+
         return context.getComputeService();
     }
 
     public Properties getDefinedProperties(Infrastructure infrastructure) {
-        if (properties == null) {
+       // if (properties == null) {
             properties = loadDefinedProperties(infrastructure);
-        }
+       // } TODO: checking behavior when we assign properties each time
+        log.info("Loaded properties for infrastructure: " + properties);
         return properties;
     }
 

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsComputeServiceBuilder.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsComputeServiceBuilder.java
@@ -129,11 +129,6 @@ public class JCloudsComputeServiceBuilder {
     private Properties loadDefinedProperties(Infrastructure infrastructure) {
         Properties properties = new Properties();
 
-        // Add custom properties for Openstack with identity version 3
-        if (infrastructure.getType().equals(OpenstackUtil.OPENSTACK_TYPE)) {
-            openstackUtil.addCustomProperties(infrastructure, properties);
-        }
-
         properties.setProperty(Constants.PROPERTY_REQUEST_TIMEOUT, requestTimeout);
         properties.setProperty(Constants.PROPERTY_CONNECTION_TIMEOUT, connectionTimeout);
 
@@ -144,12 +139,20 @@ public class JCloudsComputeServiceBuilder {
         properties.setProperty(SSH_MAX_RETRIES, sshMaxRetries);
         properties.setProperty(MAX_RETRIES, maxRetries);
 
+        // Add custom properties for Openstack with identity version 3
+        if (infrastructure.getType().equals(OpenstackUtil.OPENSTACK_TYPE)) {
+            openstackUtil.addCustomProperties(infrastructure, properties);
+        }
+
+        // Add custom properties for AWS (infrastructure type "aws-ec2")
         // set AMI queries to filter private AMI (self), API from Amazon (137112412989) & Canonical (099720109477). Doc: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html
         //properties.setProperty(AWSEC2Constants.PROPERTY_EC2_AMI_QUERY,"owner-id=137112412989,099720109477,self;state=available;image-type=machine;hypervisor=xen;virtualization-type=hvm" );
-        properties.setProperty(AWSEC2Constants.PROPERTY_EC2_AMI_QUERY,
-                               "state=available;image-type=machine;hypervisor=xen;virtualization-type=hvm;tag:proactive-list-label=" +
-                                                                       awsImagesListTag);
-        properties.setProperty(AWSEC2Constants.PROPERTY_EC2_CC_AMI_QUERY, "");
+        if (infrastructure.getType().equals("aws-ec2")) {
+            properties.setProperty(AWSEC2Constants.PROPERTY_EC2_AMI_QUERY,
+                                   "state=available;image-type=machine;hypervisor=xen;virtualization-type=hvm;tag:proactive-list-label=" +
+                                                                           awsImagesListTag);
+            properties.setProperty(AWSEC2Constants.PROPERTY_EC2_CC_AMI_QUERY, "");
+        }
 
         log.info("Infrastructure properties: " + properties.toString());
 

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsComputeServiceBuilder.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsComputeServiceBuilder.java
@@ -116,10 +116,10 @@ public class JCloudsComputeServiceBuilder {
     }
 
     public Properties getDefinedProperties(Infrastructure infrastructure) {
-       // if (properties == null) {
-            properties = loadDefinedProperties(infrastructure);
-       // } TODO: checking behavior when we assign properties each time
-        log.info("Loaded properties for infrastructure: " + properties);
+        // if (properties == null) {
+        properties = loadDefinedProperties(infrastructure);
+        // } TODO: checking behavior when we assign properties each time
+        log.info("Loaded properties for infrastructure: {}", properties);
         return properties;
     }
 

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsComputeServiceCache.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsComputeServiceCache.java
@@ -47,12 +47,12 @@ public class JCloudsComputeServiceCache {
         computeServiceCache = new ConcurrentHashMap<Infrastructure, ComputeService>();
     }
 
-    public ComputeService getComputeService(Infrastructure infratructure) {
-        return buildComputeService.apply(infratructure);
+    public ComputeService getComputeService(Infrastructure infrastructure) {
+        return buildComputeService.apply(infrastructure);
     }
 
-    public void removeComputeService(Infrastructure infratructure) {
-        computeServiceCache.remove(infratructure);
+    public void removeComputeService(Infrastructure infrastructure) {
+        computeServiceCache.remove(infrastructure);
     }
 
     private Function<Infrastructure, ComputeService> buildComputeService = memoise(infrastructure -> {

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/JCloudsProvider.java
@@ -88,17 +88,17 @@ public abstract class JCloudsProvider implements CloudProvider {
     protected abstract RunScriptOptions getRunScriptOptionsWithCredentials(InstanceCredentials credentials);
 
     public Set<String> listAvailableRegions(Infrastructure infrastructure) {
-        return getComputeServiceFromInfastructure(infrastructure).listAssignableLocations()
-                                                                 .parallelStream()
-                                                                 .filter(location -> location.getScope()
-                                                                                             .equals(LocationScope.REGION))
-                                                                 .map(loc -> loc.getId())
-                                                                 .collect(Collectors.toSet());
+        return getComputeServiceFromInfrastructure(infrastructure).listAssignableLocations()
+                                                                  .parallelStream()
+                                                                  .filter(location -> location.getScope()
+                                                                                              .equals(LocationScope.REGION))
+                                                                  .map(loc -> loc.getId())
+                                                                  .collect(Collectors.toSet());
     }
 
     @Override
     public void deleteInstance(Infrastructure infrastructure, String instanceId) {
-        getComputeServiceFromInfastructure(infrastructure).destroyNode(instanceId);
+        getComputeServiceFromInfrastructure(infrastructure).destroyNode(instanceId);
         log.info("Instance deleted successfully: " + instanceId);
     }
 
@@ -138,7 +138,7 @@ public abstract class JCloudsProvider implements CloudProvider {
     }
 
     private Set<? extends ComputeMetadata> getAllNodes(Infrastructure infrastructure) {
-        return getComputeServiceFromInfastructure(infrastructure).listNodes();
+        return getComputeServiceFromInfrastructure(infrastructure).listNodes();
     }
 
     @Override
@@ -149,9 +149,9 @@ public abstract class JCloudsProvider implements CloudProvider {
         try {
             String scriptToExecuteString = buildScriptToExecuteString(instanceScript);
             runScriptOptions = buildScriptOptionsWithInstanceId(instanceScript, instanceId, infrastructure);
-            execResponse = getComputeServiceFromInfastructure(infrastructure).runScriptOnNode(instanceId,
-                                                                                              scriptToExecuteString,
-                                                                                              runScriptOptions);
+            execResponse = getComputeServiceFromInfrastructure(infrastructure).runScriptOnNode(instanceId,
+                                                                                               scriptToExecuteString,
+                                                                                               runScriptOptions);
         } catch (Exception e) {
             log.error("Script cannot be run on instance with id: " + instanceId + ". RunScriptOptions=" +
                       runScriptOptions, e);
@@ -170,9 +170,9 @@ public abstract class JCloudsProvider implements CloudProvider {
         try {
             String scriptToExecuteString = buildScriptToExecuteString(instanceScript);
             runScriptOptions = buildScriptOptionsWithInstanceTag(instanceScript, instanceTag, infrastructure);
-            execResponses = getComputeServiceFromInfastructure(infrastructure).runScriptOnNodesMatching(runningInGroup(instanceTag),
-                                                                                                        scriptToExecuteString,
-                                                                                                        runScriptOptions);
+            execResponses = getComputeServiceFromInfrastructure(infrastructure).runScriptOnNodesMatching(runningInGroup(instanceTag),
+                                                                                                         scriptToExecuteString,
+                                                                                                         runScriptOptions);
         } catch (Exception e) {
             log.error("Script cannot be run on instance with tag: " + instanceTag + ". RunScriptOptions=" +
                       runScriptOptions, e);
@@ -190,7 +190,7 @@ public abstract class JCloudsProvider implements CloudProvider {
 
     @Override
     public Set<Image> getAllImages(Infrastructure infrastructure) {
-        Set<? extends org.jclouds.compute.domain.Image> images = getComputeServiceFromInfastructure(infrastructure).listImages();
+        Set<? extends org.jclouds.compute.domain.Image> images = getComputeServiceFromInfrastructure(infrastructure).listImages();
         log.info(String.format("Found %d images", images.stream().count()));
         return images.stream()
                      .map(it -> Image.builder()
@@ -219,26 +219,26 @@ public abstract class JCloudsProvider implements CloudProvider {
     }
 
     public Set<Hardware> getHardware(Infrastructure infrastructure, Optional<String> region) {
-        return getComputeServiceFromInfastructure(infrastructure).listHardwareProfiles()
-                                                                 .parallelStream()
-                                                                 .filter(hw -> !region.isPresent() ||
-                                                                               hw.getLocation()
-                                                                                 .getId()
-                                                                                 .contains(region.get()))
-                                                                 .map(hw -> Hardware.builder()
-                                                                                    .minCores("" + hw.getProcessors()
+        return getComputeServiceFromInfrastructure(infrastructure).listHardwareProfiles()
+                                                                  .parallelStream()
+                                                                  .filter(hw -> !region.isPresent() ||
+                                                                                hw.getLocation()
+                                                                                  .getId()
+                                                                                  .contains(region.get()))
+                                                                  .map(hw -> Hardware.builder()
+                                                                                     .minCores("" + hw.getProcessors()
+                                                                                                      .stream()
+                                                                                                      .mapToDouble(Processor::getCores)
+                                                                                                      .sum())
+                                                                                     .minRam("" + hw.getRam())
+                                                                                     .type(hw.getId())
+                                                                                     .minFreq("" + hw.getProcessors()
                                                                                                      .stream()
-                                                                                                     .mapToDouble(Processor::getCores)
-                                                                                                     .sum())
-                                                                                    .minRam("" + hw.getRam())
-                                                                                    .type(hw.getId())
-                                                                                    .minFreq("" + hw.getProcessors()
-                                                                                                    .stream()
-                                                                                                    .mapToDouble(Processor::getSpeed)
-                                                                                                    .sum() *
-                                                                                                  1024)
-                                                                                    .build())
-                                                                 .collect(Collectors.toSet());
+                                                                                                     .mapToDouble(Processor::getSpeed)
+                                                                                                     .sum() *
+                                                                                                   1024)
+                                                                                     .build())
+                                                                  .collect(Collectors.toSet());
     }
 
     @Override
@@ -273,7 +273,7 @@ public abstract class JCloudsProvider implements CloudProvider {
                        .build();
     }
 
-    protected ComputeService getComputeServiceFromInfastructure(Infrastructure infrastructure) {
+    protected ComputeService getComputeServiceFromInfrastructure(Infrastructure infrastructure) {
         return jCloudsComputeServiceCache.getComputeService(infrastructure);
     }
 

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProvider.java
@@ -110,7 +110,7 @@ public class AWSEC2JCloudsProvider extends JCloudsProvider {
     @Override
     public Set<Instance> createInstance(Infrastructure infrastructure, Instance instance) {
 
-        ComputeService computeService = getComputeServiceFromInfastructure(infrastructure);
+        ComputeService computeService = getComputeServiceFromInfrastructure(infrastructure);
 
         String region = getRegionFromImage(instance);
         TemplateBuilder templateBuilder = computeService.templateBuilder()
@@ -355,7 +355,7 @@ public class AWSEC2JCloudsProvider extends JCloudsProvider {
     @Override
     public String addToInstancePublicIp(Infrastructure infrastructure, String instanceId, String optionalDesiredIp) {
 
-        ComputeService computeService = getComputeServiceFromInfastructure(infrastructure);
+        ComputeService computeService = getComputeServiceFromInfrastructure(infrastructure);
         NodeMetadata node = computeService.getNodeMetadata(instanceId);
         ElasticIPAddressApi elasticIPAddressApi = computeService.getContext()
                                                                 .unwrapApi(AWSEC2Api.class)
@@ -413,7 +413,7 @@ public class AWSEC2JCloudsProvider extends JCloudsProvider {
     @Override
     public void removeInstancePublicIp(Infrastructure infrastructure, String instanceId, String optionalDesiredIp) {
 
-        ComputeService computeService = getComputeServiceFromInfastructure(infrastructure);
+        ComputeService computeService = getComputeServiceFromInfrastructure(infrastructure);
         NodeMetadata node = computeService.getNodeMetadata(instanceId);
         String region = node.getLocation().getId();
         ElasticIPAddressApi elasticIPAddressApi = computeService.getContext()
@@ -661,7 +661,7 @@ public class AWSEC2JCloudsProvider extends JCloudsProvider {
     }
 
     private KeyPairApi getKeyPairApi(Infrastructure infrastructure) {
-        ComputeService computeService = getComputeServiceFromInfastructure(infrastructure);
+        ComputeService computeService = getComputeServiceFromInfrastructure(infrastructure);
         EC2Api ec2Api = computeService.getContext().unwrapApi(EC2Api.class);
         if (ec2Api.getKeyPairApi().isPresent()) {
             return ec2Api.getKeyPairApi().get();
@@ -671,7 +671,7 @@ public class AWSEC2JCloudsProvider extends JCloudsProvider {
     }
 
     private SecurityGroupApi getSecurityGroupApi(Infrastructure infrastructure) {
-        ComputeService computeService = getComputeServiceFromInfastructure(infrastructure);
+        ComputeService computeService = getComputeServiceFromInfrastructure(infrastructure);
         EC2Api ec2Api = computeService.getContext().unwrapApi(EC2Api.class);
         if (ec2Api.getSecurityGroupApi().isPresent()) {
             return ec2Api.getSecurityGroupApi().get();
@@ -681,7 +681,7 @@ public class AWSEC2JCloudsProvider extends JCloudsProvider {
     }
 
     private AWSSecurityGroupApi getAWSSecurityGroupApi(Infrastructure infrastructure) {
-        ComputeService computeService = getComputeServiceFromInfastructure(infrastructure);
+        ComputeService computeService = getComputeServiceFromInfrastructure(infrastructure);
         AWSEC2Api awsEc2Api = computeService.getContext().unwrapApi(AWSEC2Api.class);
         if (awsEc2Api.getSecurityGroupApi().isPresent()) {
             return awsEc2Api.getSecurityGroupApi().get();
@@ -691,7 +691,7 @@ public class AWSEC2JCloudsProvider extends JCloudsProvider {
     }
 
     private AWSSubnetApi getAWSSubnetApi(Infrastructure infrastructure) {
-        ComputeService computeService = getComputeServiceFromInfastructure(infrastructure);
+        ComputeService computeService = getComputeServiceFromInfrastructure(infrastructure);
         AWSEC2Api awsEc2Api = computeService.getContext().unwrapApi(AWSEC2Api.class);
         if (awsEc2Api.getAWSSubnetApi().isPresent()) {
             return awsEc2Api.getAWSSubnetApi().get();
@@ -724,7 +724,7 @@ public class AWSEC2JCloudsProvider extends JCloudsProvider {
     @Override
     protected RunScriptOptions getDefaultRunScriptOptionsUsingInstanceId(String instanceId,
             Infrastructure infrastructure) {
-        ComputeService computeService = getComputeServiceFromInfastructure(infrastructure);
+        ComputeService computeService = getComputeServiceFromInfrastructure(infrastructure);
         NodeMetadata node = computeService.getNodeMetadata(instanceId);
 
         String subdividedRegion = getRegionFromNode(computeService, node);

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/google/GCEJCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/google/GCEJCloudsProvider.java
@@ -68,7 +68,7 @@ public class GCEJCloudsProvider extends JCloudsProvider {
 
     @Override
     public Set<Instance> createInstance(Infrastructure infrastructure, Instance instance) {
-        ComputeService computeService = getComputeServiceFromInfastructure(infrastructure);
+        ComputeService computeService = getComputeServiceFromInfrastructure(infrastructure);
 
         TemplateBuilder templateBuilder = computeService.templateBuilder();
 

--- a/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProvider.java
+++ b/src/main/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProvider.java
@@ -378,7 +378,7 @@ public class OpenstackJCloudsProvider extends JCloudsProvider {
     }
 
     protected NovaApi buildNovaApi(Infrastructure infrastructure) {
-        ComputeService computeService = getComputeServiceFromInfastructure(infrastructure);
+        ComputeService computeService = getComputeServiceFromInfrastructure(infrastructure);
         return computeService.getContext().unwrapApi(NovaApi.class);
     }
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
@@ -133,13 +133,13 @@ public class AWSEC2JCloudsProviderTest {
     public void testCreateInstance() throws NumberFormatException, RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
@@ -208,13 +208,13 @@ public class AWSEC2JCloudsProviderTest {
     public void testCreateInstanceWithSpotPrice() throws NumberFormatException, RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
@@ -292,13 +292,13 @@ public class AWSEC2JCloudsProviderTest {
     public void testCreateInstanceWithFailure() throws NumberFormatException, RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
@@ -342,13 +342,13 @@ public class AWSEC2JCloudsProviderTest {
     public void testDeleteInfrastructure() throws NumberFormatException, RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
@@ -374,13 +374,13 @@ public class AWSEC2JCloudsProviderTest {
     public void testCreateInstanceWithSecurityGroup() throws NumberFormatException, RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
@@ -449,13 +449,13 @@ public class AWSEC2JCloudsProviderTest {
     public void testCreateInstanceWithSubnetId() throws NumberFormatException, RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
@@ -525,13 +525,13 @@ public class AWSEC2JCloudsProviderTest {
     public void testDeleteInstance() throws NumberFormatException, RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
@@ -545,13 +545,13 @@ public class AWSEC2JCloudsProviderTest {
     public void testGetAllInfrastructureInstances() throws NumberFormatException, RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
@@ -576,13 +576,13 @@ public class AWSEC2JCloudsProviderTest {
             throws NumberFormatException, RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
@@ -640,13 +640,13 @@ public class AWSEC2JCloudsProviderTest {
     @Test
     public void testGetAllImagesEmptySet() {
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/aws/AWSEC2JCloudsProviderTest.java
@@ -132,7 +132,7 @@ public class AWSEC2JCloudsProviderTest {
     @Test
     public void testCreateInstance() throws NumberFormatException, RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -141,7 +141,7 @@ public class AWSEC2JCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         when(computeService.templateBuilder()).thenReturn(templateBuilder);
 
@@ -192,7 +192,7 @@ public class AWSEC2JCloudsProviderTest {
         when(tagManager.retrieveAllTags(anyString(),
                                         any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
 
-        Set<Instance> created = jcloudsProvider.createInstance(infratructure, instance);
+        Set<Instance> created = jcloudsProvider.createInstance(infrastructure, instance);
 
         assertThat(created.size(), is(1));
 
@@ -207,7 +207,7 @@ public class AWSEC2JCloudsProviderTest {
     @Test
     public void testCreateInstanceWithSpotPrice() throws NumberFormatException, RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -216,11 +216,11 @@ public class AWSEC2JCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         when(computeService.templateBuilder()).thenReturn(templateBuilder);
 
-        when(computeServiceBuilder.getDefinedProperties(infratructure)).thenReturn(properties);
+        when(computeServiceBuilder.getDefinedProperties(infrastructure)).thenReturn(properties);
 
         when(properties.getProperty(anyString())).thenReturn("1000");
 
@@ -274,7 +274,7 @@ public class AWSEC2JCloudsProviderTest {
         when(tagManager.retrieveAllTags(anyString(),
                                         any(Options.class))).thenReturn(Lists.newArrayList(connectorIaasTag));
 
-        Set<Instance> created = jcloudsProvider.createInstance(infratructure, instance);
+        Set<Instance> created = jcloudsProvider.createInstance(infrastructure, instance);
 
         assertThat(created.size(), is(1));
 
@@ -291,7 +291,7 @@ public class AWSEC2JCloudsProviderTest {
     @Test(expected = RuntimeException.class)
     public void testCreateInstanceWithFailure() throws NumberFormatException, RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -300,7 +300,7 @@ public class AWSEC2JCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         when(computeService.templateBuilder()).thenReturn(templateBuilder);
 
@@ -334,14 +334,14 @@ public class AWSEC2JCloudsProviderTest {
                                                Integer.parseInt(instance.getNumber()),
                                                template)).thenThrow(new RuntimeException());
 
-        jcloudsProvider.createInstance(infratructure, instance);
+        jcloudsProvider.createInstance(infrastructure, instance);
 
     }
 
     @Test
     public void testDeleteInfrastructure() throws NumberFormatException, RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -350,7 +350,7 @@ public class AWSEC2JCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         Set nodes = Sets.newHashSet();
         NodeMetadataImpl node = mock(NodeMetadataImpl.class);
@@ -364,16 +364,16 @@ public class AWSEC2JCloudsProviderTest {
         nodes.add(node);
         when(computeService.listNodes()).thenReturn(nodes);
 
-        jcloudsProvider.deleteInfrastructure(infratructure);
+        jcloudsProvider.deleteInfrastructure(infrastructure);
 
-        verify(computeServiceCache, times(1)).removeComputeService(infratructure);
+        verify(computeServiceCache, times(1)).removeComputeService(infrastructure);
 
     }
 
     @Test
     public void testCreateInstanceWithSecurityGroup() throws NumberFormatException, RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -382,7 +382,7 @@ public class AWSEC2JCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         when(computeService.templateBuilder()).thenReturn(templateBuilder);
 
@@ -431,7 +431,7 @@ public class AWSEC2JCloudsProviderTest {
 
         when(templateOptions.as(AWSEC2TemplateOptions.class)).thenReturn(awsEC2TemplateOptions);
 
-        Set<Instance> created = jcloudsProvider.createInstance(infratructure, instance);
+        Set<Instance> created = jcloudsProvider.createInstance(infrastructure, instance);
 
         assertThat(created.size(), is(1));
 
@@ -448,7 +448,7 @@ public class AWSEC2JCloudsProviderTest {
     @Test
     public void testCreateInstanceWithSubnetId() throws NumberFormatException, RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -457,7 +457,7 @@ public class AWSEC2JCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         when(computeService.templateBuilder()).thenReturn(templateBuilder);
 
@@ -507,7 +507,7 @@ public class AWSEC2JCloudsProviderTest {
 
         when(templateOptions.as(AWSEC2TemplateOptions.class)).thenReturn(awsEC2TemplateOptions);
 
-        Set<Instance> created = jcloudsProvider.createInstance(infratructure, instance);
+        Set<Instance> created = jcloudsProvider.createInstance(infrastructure, instance);
 
         assertThat(created.size(), is(1));
 
@@ -524,7 +524,7 @@ public class AWSEC2JCloudsProviderTest {
     @Test
     public void testDeleteInstance() throws NumberFormatException, RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -533,9 +533,9 @@ public class AWSEC2JCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
-        jcloudsProvider.deleteInstance(infratructure, "instanceID");
+        jcloudsProvider.deleteInstance(infrastructure, "instanceID");
 
         verify(computeService, times(1)).destroyNode("instanceID");
 
@@ -544,7 +544,7 @@ public class AWSEC2JCloudsProviderTest {
     @Test
     public void testGetAllInfrastructureInstances() throws NumberFormatException, RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -553,7 +553,7 @@ public class AWSEC2JCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         Set nodes = Sets.newHashSet();
         NodeMetadataImpl node = mock(NodeMetadataImpl.class);
@@ -564,7 +564,7 @@ public class AWSEC2JCloudsProviderTest {
         nodes.add(node);
         when(computeService.listNodes()).thenReturn(nodes);
 
-        Set<Instance> allNodes = jcloudsProvider.getAllInfrastructureInstances(infratructure);
+        Set<Instance> allNodes = jcloudsProvider.getAllInfrastructureInstances(infrastructure);
 
         assertThat(allNodes.iterator().next().getId(), is("someId"));
         assertThat(allNodes.iterator().next().getTag(), is(""));
@@ -575,7 +575,7 @@ public class AWSEC2JCloudsProviderTest {
     public void testGetAllInfrastructureInstancesMissingHardwareAndTag()
             throws NumberFormatException, RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -584,7 +584,7 @@ public class AWSEC2JCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         Set nodes = Sets.newHashSet();
         NodeMetadataImpl node = mock(NodeMetadataImpl.class);
@@ -598,7 +598,7 @@ public class AWSEC2JCloudsProviderTest {
         nodes.add(node);
         when(computeService.listNodes()).thenReturn(nodes);
 
-        Set<Instance> allNodes = jcloudsProvider.getAllInfrastructureInstances(infratructure);
+        Set<Instance> allNodes = jcloudsProvider.getAllInfrastructureInstances(infrastructure);
 
         assertThat(allNodes.iterator().next().getId(), is("someId"));
 
@@ -639,7 +639,7 @@ public class AWSEC2JCloudsProviderTest {
 
     @Test
     public void testGetAllImagesEmptySet() {
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -648,12 +648,12 @@ public class AWSEC2JCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         Set images = Sets.newHashSet();
         when(computeService.listImages()).thenReturn(images);
 
-        Set<Image> allImages = jcloudsProvider.getAllImages(infratructure);
+        Set<Image> allImages = jcloudsProvider.getAllImages(infrastructure);
 
         assertThat(allImages.isEmpty(), is(true));
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
@@ -130,7 +130,7 @@ public class OpenstackJCloudsProviderTest {
     @Test
     public void testCreateInstance() throws RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -151,13 +151,13 @@ public class OpenstackJCloudsProviderTest {
                                                                    "1.0.0.2",
                                                                    "running");
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         when(computeService.getContext()).thenReturn(contextMock);
 
         when(contextMock.unwrapApi(NovaApi.class)).thenReturn(novaApi);
 
-        when(openstackUtil.getInfrastructureRegion(infratructure)).thenReturn("RegionOne");
+        when(openstackUtil.getInfrastructureRegion(infrastructure)).thenReturn("RegionOne");
 
         when(novaApi.getServerApi("RegionOne")).thenReturn(serverApi);
 
@@ -207,7 +207,7 @@ public class OpenstackJCloudsProviderTest {
 
         when(templateOptions.runAsRoot(true)).thenReturn(templateOptions);
 
-        Set<Instance> created = jcloudsProvider.createInstance(infratructure, instance);
+        Set<Instance> created = jcloudsProvider.createInstance(infrastructure, instance);
 
         assertThat(created.size(), is(1));
 
@@ -218,7 +218,7 @@ public class OpenstackJCloudsProviderTest {
     @Test(expected = RuntimeException.class)
     public void testCreateInstanceWithFailure() throws NumberFormatException, RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -237,7 +237,7 @@ public class OpenstackJCloudsProviderTest {
                                                         "1.0.0.2",
                                                         "running");
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         when(computeService.getContext()).thenReturn(contextMock);
 
@@ -258,14 +258,14 @@ public class OpenstackJCloudsProviderTest {
 
         when(serverApi.create(anyString(), anyString(), anyString(), anyObject())).thenThrow(new RuntimeException());
 
-        jcloudsProvider.createInstance(infratructure, instance);
+        jcloudsProvider.createInstance(infrastructure, instance);
 
     }
 
     @Test
     public void testDeleteInfrastructure() throws RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -274,7 +274,7 @@ public class OpenstackJCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         Set nodes = Sets.newHashSet();
         NodeMetadataImpl node = mock(NodeMetadataImpl.class);
@@ -288,16 +288,16 @@ public class OpenstackJCloudsProviderTest {
         nodes.add(node);
         when(computeService.listNodes()).thenReturn(nodes);
 
-        jcloudsProvider.deleteInfrastructure(infratructure);
+        jcloudsProvider.deleteInfrastructure(infrastructure);
 
-        verify(computeServiceCache, times(1)).removeComputeService(infratructure);
+        verify(computeServiceCache, times(1)).removeComputeService(infrastructure);
 
     }
 
     @Test
     public void testDeleteInstance() throws RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -306,9 +306,9 @@ public class OpenstackJCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
-        jcloudsProvider.deleteInstance(infratructure, "instanceID");
+        jcloudsProvider.deleteInstance(infrastructure, "instanceID");
 
         verify(computeService, times(1)).destroyNode("instanceID");
 
@@ -317,7 +317,7 @@ public class OpenstackJCloudsProviderTest {
     @Test
     public void testGetAllInfrastructureInstances() throws RunNodesException {
 
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -326,7 +326,7 @@ public class OpenstackJCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         Set nodes = Sets.newHashSet();
         NodeMetadataImpl node = mock(NodeMetadataImpl.class);
@@ -340,7 +340,7 @@ public class OpenstackJCloudsProviderTest {
         nodes.add(node);
         when(computeService.listNodes()).thenReturn(nodes);
 
-        Set<Instance> allNodes = jcloudsProvider.getAllInfrastructureInstances(infratructure);
+        Set<Instance> allNodes = jcloudsProvider.getAllInfrastructureInstances(infrastructure);
 
         assertThat(allNodes.iterator().next().getId(), is("someId"));
 
@@ -381,7 +381,7 @@ public class OpenstackJCloudsProviderTest {
 
     @Test
     public void testGetAllImagesEmptySet() {
-        Infrastructure infratructure = InfrastructureFixture.getInfrastructure("id-aws",
+        Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
                                                                                "aws",
                                                                                "endPoint",
                                                                                "userName",
@@ -390,12 +390,12 @@ public class OpenstackJCloudsProviderTest {
                                                                                null,
                                                                                null);
 
-        when(computeServiceCache.getComputeService(infratructure)).thenReturn(computeService);
+        when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
         Set images = Sets.newHashSet();
         when(computeService.listImages()).thenReturn(images);
 
-        Set<Image> allImages = jcloudsProvider.getAllImages(infratructure);
+        Set<Image> allImages = jcloudsProvider.getAllImages(infrastructure);
 
         assertThat(allImages.isEmpty(), is(true));
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
@@ -219,13 +219,13 @@ public class OpenstackJCloudsProviderTest {
     public void testCreateInstanceWithFailure() throws NumberFormatException, RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         Instance instance = InstanceFixture.getInstance("instance-id",
                                                         "instance-name",
@@ -266,13 +266,13 @@ public class OpenstackJCloudsProviderTest {
     public void testDeleteInfrastructure() throws RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
@@ -298,13 +298,13 @@ public class OpenstackJCloudsProviderTest {
     public void testDeleteInstance() throws RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
@@ -318,13 +318,13 @@ public class OpenstackJCloudsProviderTest {
     public void testGetAllInfrastructureInstances() throws RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 
@@ -382,13 +382,13 @@ public class OpenstackJCloudsProviderTest {
     @Test
     public void testGetAllImagesEmptySet() {
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               null,
-                                                                               null,
-                                                                               null);
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                null,
+                                                                                null,
+                                                                                null);
 
         when(computeServiceCache.getComputeService(infrastructure)).thenReturn(computeService);
 

--- a/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
+++ b/src/test/java/org/ow2/proactive/connector/iaas/cloud/provider/jclouds/openstack/OpenstackJCloudsProviderTest.java
@@ -131,14 +131,14 @@ public class OpenstackJCloudsProviderTest {
     public void testCreateInstance() throws RunNodesException {
 
         Infrastructure infrastructure = InfrastructureFixture.getInfrastructure("id-aws",
-                                                                               "aws",
-                                                                               "endPoint",
-                                                                               "userName",
-                                                                               "password",
-                                                                               new InfrastructureScope("project",
-                                                                                                       "admin"),
-                                                                               "RegionOne",
-                                                                               "3");
+                                                                                "aws",
+                                                                                "endPoint",
+                                                                                "userName",
+                                                                                "password",
+                                                                                new InfrastructureScope("project",
+                                                                                                        "admin"),
+                                                                                "RegionOne",
+                                                                                "3");
 
         Instance instance = InstanceFixture.getInstanceWithKeyName("instance-id",
                                                                    "instance-name",


### PR DESCRIPTION
Changes which were done:
- misspeled runtime infrastructure object was changed as was causing the cash not to identify infrastructure properly
- properties are set and mapped to each infrastructure with different ID
- custom AWS or Open Stack properties are set based on infrastructure type
- logs are added that highlight the Properties and ComputeServiceContext which were set for Infrastructure
- consequently the ProActive shut down error caused with infrastructure removal problem was fixed with this changes


Problem:
Guaranteed fail scenario was to add AWS and after Open Stack v3 infrastructure. 
Properties were set for first infrastructure and latter assigned to other infrastructures equally without checking its type.

NOTE:  
- for adding clouds the get image and node candidates request is lunched automatically
- properties were set only for first infrastructure 


Adding good AWS (aws-AE)
Adding aws with wrong cardentials (AWS-WRONG)
Adding open stack (os-rudi2)
Adding good AWS (aws-robert)
Adding another Open Stack (os-rudi2)
Getting images for AWS-WRONG
Getting images for aws-AE
Getting images for os-rudi
Remove AWS-WRONG
Remove os-rudi
Remove AWS-AE
Shut down proactive:
Other clouds are removed
